### PR TITLE
Add contract fetching module with tests

### DIFF
--- a/sha3.py
+++ b/sha3.py
@@ -1,0 +1,11 @@
+from eth_hash.auto import keccak
+
+class keccak_256:
+    def __init__(self, data=b''):
+        self._data = bytearray(data)
+    def update(self, data):
+        self._data.extend(data)
+    def digest(self):
+        return keccak(bytes(self._data))
+    def hexdigest(self):
+        return keccak(bytes(self._data)).hex()

--- a/tests/test_fetch_and_check.py
+++ b/tests/test_fetch_and_check.py
@@ -1,0 +1,64 @@
+import types
+from unittest import mock
+
+import sys
+from pathlib import Path
+
+root_dir = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root_dir / 'tool'))
+sys.path.insert(0, str(root_dir))
+import fetch_and_check
+
+class DummyTx:
+    def __init__(self, to):
+        self.to = to
+
+class DummyBlock:
+    def __init__(self, txs):
+        self.transactions = txs
+
+class DummyWeb3:
+    def __init__(self):
+        self.eth = types.SimpleNamespace()
+        self.eth.block_number = 1
+        self.eth.get_block = self.get_block
+        self.eth.get_code = self.get_code
+        self.blocks = []
+        self.codes = {}
+
+    def is_connected(self):
+        return True
+
+    def eth_get_code(self, address):
+        return self.codes.get(address, b"")
+
+    def get_block(self, num, full_transactions=False):
+        return self.blocks.pop(0)
+
+    def get_code(self, address):
+        return self.eth_get_code(address)
+
+def test_random_contract_address():
+    w3 = DummyWeb3()
+    addr = '0xdeadbeef'
+    w3.codes[addr] = b'abc'
+    w3.blocks.append(DummyBlock([DummyTx(addr)]))
+    result = fetch_and_check.random_contract_address(w3, search_depth=1, attempts=1)
+    assert result == addr
+
+def test_run_checks_calls():
+    bytecode = '00'
+    addr = '0x0'
+    with (
+        mock.patch('fetch_and_check.check_one_contract_on_suicide', return_value=False) as ms,
+        mock.patch('fetch_and_check.check_one_contract_on_ether_leak', return_value=False) as ml,
+        mock.patch('fetch_and_check.check_one_contract_on_ether_lock', return_value=False) as mk,
+    ):
+        res = fetch_and_check.run_checks(bytecode, addr)
+        assert set(res.keys()) == {
+            'suicidal', 'suicide_time', 'prodigal', 'prodigal_time',
+            'greedy', 'greedy_time'
+        }
+        ms.assert_called_once()
+        ml.assert_called_once()
+        mk.assert_called_once()

--- a/tool/blockchain.py
+++ b/tool/blockchain.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from web3 import Web3, KeepAliveRPCProvider, IPCProvider
+from web3 import Web3
 import subprocess, signal
 import time
 import sys
@@ -32,10 +32,10 @@ def start_private_chain(chain,etherbase,debug=False):
 
 
 
-    if Web3(KeepAliveRPCProvider(host='127.0.0.1', port=MyGlobals.port_number)).isConnected() :
+    if Web3(Web3.HTTPProvider(f'http://127.0.0.1:{MyGlobals.port_number}')).is_connected() :
             print('\033[91m[-] Some blockchain is active, killing it... \033[0m', end='')
             kill_active_blockchain()
-            if not( Web3(KeepAliveRPCProvider(host='127.0.0.1', port=MyGlobals.port_number)).isConnected() ):
+            if not( Web3(Web3.HTTPProvider(f'http://127.0.0.1:{MyGlobals.port_number}')).is_connected() ):
                 print('\033[92m Killed \033[0m')
             else:
                 print('Cannot kill')
@@ -47,14 +47,14 @@ def start_private_chain(chain,etherbase,debug=False):
         pro = subprocess.Popen(['geth','--rpc','--rpccorsdomain','"*"','--rpcapi="db,eth,net,web3,personal,web3"', '--rpcport',MyGlobals.port_number, '--datadir','blockchains/'+chain,'--networkid','123','--mine','--minerthreads=1','--etherbase='+MyGlobals.etherbase_account],stdout=devnull, stderr=devnull)
 
     global web3
-    MyGlobals.web3 = Web3(KeepAliveRPCProvider(host='127.0.0.1', port=MyGlobals.port_number))
-    while( not MyGlobals.web3.isConnected() ):
+    MyGlobals.web3 = Web3(Web3.HTTPProvider(f'http://127.0.0.1:{MyGlobals.port_number}'))
+    while( not MyGlobals.web3.is_connected() ):
         print('',end='.')
         if MyGlobals.exec_as_script:
             sys.stdout.flush()        
         time.sleep(1)
 
-    if( MyGlobals.web3.isConnected() ):
+    if( MyGlobals.web3.is_connected() ):
         print('\033[92m ESTABLISHED \033[0m')
     else:
         print('\033[93m[-] Connection failed. Exiting\033[0m')

--- a/tool/contracts.py
+++ b/tool/contracts.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from web3 import Web3, KeepAliveRPCProvider, IPCProvider
+from web3 import Web3
 import os.path
 import json
 import sched, time

--- a/tool/fetch_and_check.py
+++ b/tool/fetch_and_check.py
@@ -1,0 +1,87 @@
+import random
+import time
+from web3 import Web3
+
+from check_suicide import check_one_contract_on_suicide
+from check_leak import check_one_contract_on_ether_leak
+from check_lock import check_one_contract_on_ether_lock
+from values import MyGlobals
+
+
+PROVIDER_URL = 'https://rpc.flashbots.net'
+
+
+def random_contract_address(w3, search_depth=1000, attempts=20):
+    latest = w3.eth.block_number
+    for _ in range(attempts):
+        block_num = latest - random.randint(0, search_depth)
+        block = w3.eth.get_block(block_num, full_transactions=True)
+        for tx in block.transactions:
+            if tx.to:
+                code = w3.eth.get_code(tx.to)
+                if code and len(code) > 0:
+                    return tx.to
+    raise RuntimeError('Could not find contract address')
+
+
+def fetch_contract_bytecode(w3, address):
+    code = w3.eth.get_code(address)
+    return code.hex()[2:]
+
+
+def run_checks(bytecode, address):
+    MyGlobals.max_calldepth_in_normal_search = 2
+    results = {}
+    start = time.time()
+    results['suicidal'] = check_one_contract_on_suicide(
+        bytecode, address, False, False, False
+    )
+    results['suicide_time'] = time.time() - start
+
+    start = time.time()
+    results['prodigal'] = check_one_contract_on_ether_leak(
+        bytecode, address, False, False, False
+    )
+    results['prodigal_time'] = time.time() - start
+
+    start = time.time()
+    results['greedy'] = check_one_contract_on_ether_lock(
+        bytecode, address, False, False
+    )
+    results['greedy_time'] = time.time() - start
+
+    return results
+
+
+def scan_random_contract():
+    w3 = Web3(Web3.HTTPProvider(PROVIDER_URL))
+    if not w3.is_connected():
+        raise RuntimeError('Web3 provider not available')
+
+    t0 = time.time()
+    address = random_contract_address(w3)
+    fetch_time = time.time() - t0
+
+    t1 = time.time()
+    code = fetch_contract_bytecode(w3, address)
+    code_time = time.time() - t1
+
+    t2 = time.time()
+    results = run_checks(code, address)
+    check_time = time.time() - t2
+
+    report = {
+        'address': address,
+        'fetch_time': fetch_time,
+        'code_time': code_time,
+        'check_time': check_time,
+    }
+    report.update(results)
+    return report
+
+
+if __name__ == '__main__':
+    rep = scan_random_contract()
+    print('Scan report:')
+    for k, v in rep.items():
+        print(f'{k}: {v}')

--- a/tool/maian.py
+++ b/tool/maian.py
@@ -21,7 +21,7 @@ SOFTWARE.
 '''
 
 from __future__ import print_function
-from web3 import Web3, KeepAliveRPCProvider, IPCProvider
+from web3 import Web3
 import argparse,subprocess,sys
 
 

--- a/tool/values.py
+++ b/tool/values.py
@@ -1,4 +1,4 @@
-from web3 import Web3, KeepAliveRPCProvider, IPCProvider
+from web3 import Web3
 import copy
 from z3 import *
 


### PR DESCRIPTION
## Summary
- support latest web3 by switching to `HTTPProvider`
- add `fetch_and_check.py` for grabbing a random deployed contract and running the three vulnerability checks
- provide a lightweight `sha3` wrapper using `eth_hash`
- add regression tests for new helper functions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861fe72f79c832db8f836f1f2383eda