### PR TITLE
Add multi-contract scan support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+This is a repository for Maian, a Python tool for detecting vulnerabilities in Ethereum smart contracts. Most code resides in the `tool` directory. Tests live in `tests` and use pytest.
+
+Coding conventions:
+- Python 3 code with standard library modules. Maintain compatibility with Python 3.8+.
+- Use 4-space indentation.
+- Keep functions small and documented with docstrings where practical.
+
+Running tests:
+- Install dependencies with `pip install web3 z3-solver`.
+- Execute the full test suite with `pytest -q` from the repository root.
+
+Any new scripts or modules should include simple unit tests under `tests/` and should avoid network calls during tests by using mocks.

--- a/README.md
+++ b/README.md
@@ -36,13 +36,14 @@ A snapshot of one run is given below
 
 ### Automated Fetching
 
-The `fetch_and_check.py` utility can fetch a random contract directly from a
-public Ethereum node and run the Maian checks on it. By default the script
-connects to Mainnet but other networks can be selected with the `--network`
-option:
+The `fetch_and_check.py` utility can fetch one or more random contracts
+directly from a public Ethereum node and run the Maian checks on them. By
+default the script connects to Mainnet but other networks can be selected with
+the `--network` option. The number of contracts to scan is controlled with
+`--count`:
 
 ```
-$ python fetch_and_check.py --network mainnet
+$ python fetch_and_check.py --network mainnet --count 5
 ```
 
 Additional networks can be added to the tool in the future.

--- a/tests/test_fetch_and_check.py
+++ b/tests/test_fetch_and_check.py
@@ -73,3 +73,10 @@ def test_get_provider_url_mainnet():
 def test_get_provider_url_invalid():
     with pytest.raises(ValueError):
         fetch_and_check.get_provider_url('foobar')
+
+
+def test_scan_multiple_contracts():
+    with mock.patch('fetch_and_check.scan_random_contract', return_value={'a':1}) as m:
+        res = fetch_and_check.scan_multiple_contracts(count=3, network='mainnet')
+        assert res == [{'a':1}, {'a':1}, {'a':1}]
+        assert m.call_count == 3

--- a/tool/fetch_and_check.py
+++ b/tool/fetch_and_check.py
@@ -94,9 +94,17 @@ def scan_random_contract(network: str = 'mainnet'):
     return report
 
 
+def scan_multiple_contracts(count: int, network: str = 'mainnet'):
+    """Fetch and scan ``count`` random contracts from ``network``."""
+    reports = []
+    for _ in range(count):
+        reports.append(scan_random_contract(network=network))
+    return reports
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
-        description='Fetch a random contract from a network and run Maian checks'
+        description='Fetch random contracts from a network and run Maian checks'
     )
     parser.add_argument(
         '-n', '--network',
@@ -104,9 +112,14 @@ if __name__ == '__main__':
         choices=sorted(NETWORK_PROVIDERS.keys()),
         help='Ethereum network to use (default: mainnet)',
     )
+    parser.add_argument(
+        '-c', '--count', type=int, default=1,
+        help='number of contracts to scan (default: 1)'
+    )
     args = parser.parse_args()
 
-    rep = scan_random_contract(network=args.network)
-    print('Scan report:')
-    for k, v in rep.items():
-        print(f'{k}: {v}')
+    reports = scan_multiple_contracts(count=args.count, network=args.network)
+    for i, rep in enumerate(reports, 1):
+        print(f'Scan {i}:')
+        for k, v in rep.items():
+            print(f'  {k}: {v}')


### PR DESCRIPTION
## Summary
- document basic repo info and testing instructions in AGENTS.md
- allow fetching multiple contracts with `scan_multiple_contracts`
- expose `--count` option in `fetch_and_check.py`
- document the new option in the README
- test multi-contract behaviour

## Testing
- `pytest -q`
- `python tool/fetch_and_check.py --network mainnet --count 10 | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6862dd422ec8832d9ede2b576c45143b