### PR TITLE
Add multi-contract scan result lists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,5 +13,7 @@ Unique scanning:
 - The `fetch_and_check.py` utility saves scanned contract addresses to
   `reports/scanned_addresses.txt` by default. Duplicate addresses are skipped
   unless the `--allow-duplicates` flag is passed.
+  Addresses flagged as vulnerable are appended to
+  `reports/suicidal.txt`, `reports/prodigal.txt`, and `reports/greedy.txt`.
 
 Any new scripts or modules should include simple unit tests under `tests/` and should avoid network calls during tests by using mocks.

--- a/tests/test_fetch_and_check.py
+++ b/tests/test_fetch_and_check.py
@@ -100,3 +100,52 @@ def test_scan_multiple_contracts_allow_duplicates():
         res = fetch_and_check.scan_multiple_contracts(count=2, network='mainnet', unique=False)
         assert res == [{'address': '0x1'}, {'address': '0x1'}]
         assert m.call_count == 2
+
+
+def test_scan_multiple_contracts_respects_existing_file(tmp_path):
+    address_file = tmp_path / 'addrs.txt'
+    address_file.write_text('0x1\n')
+
+    responses = [
+        {'address': '0x1'},
+        {'address': '0x2'},
+        {'address': '0x3'},
+    ]
+
+    def side_effect(*_, **__):
+        return responses.pop(0)
+
+    with mock.patch('fetch_and_check.scan_random_contract', side_effect=side_effect) as m:
+        res = fetch_and_check.scan_multiple_contracts(
+            count=2,
+            network='mainnet',
+            address_file=str(address_file),
+        )
+        assert [r['address'] for r in res] == ['0x2', '0x3']
+        assert m.call_count == 3
+    assert address_file.read_text().splitlines() == ['0x1', '0x2', '0x3']
+
+
+def test_vulnerable_addresses_written(tmp_path):
+    report_dir = tmp_path / 'reports'
+
+    reports = [
+        {'address': '0x1', 'suicidal': True, 'prodigal': False, 'greedy': False},
+        {'address': '0x2', 'suicidal': False, 'prodigal': True, 'greedy': True},
+    ]
+
+    def side_effect(*_, **__):
+        return reports.pop(0)
+
+    with mock.patch('fetch_and_check.scan_random_contract', side_effect=side_effect):
+        fetch_and_check.scan_multiple_contracts(
+            count=2,
+            network='mainnet',
+            address_file=None,
+            report_dir=str(report_dir),
+        )
+
+    assert (report_dir / 'suicidal.txt').read_text().splitlines() == ['0x1']
+    assert (report_dir / 'prodigal.txt').read_text().splitlines() == ['0x2']
+    assert (report_dir / 'greedy.txt').read_text().splitlines() == ['0x2']
+


### PR DESCRIPTION
## Summary
- avoid rescanning addresses across runs in `fetch_and_check.py`
- write vulnerable contract addresses to `reports/suicidal.txt`, `reports/prodigal.txt`, and `reports/greedy.txt`
- add `--report-dir` CLI option
- update tests for new behaviour
- document output lists in `AGENTS.md`

## Testing
- `pip install web3 z3-solver`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862ead13ec4832d8ef8c3e38f998a9b