### PR TITLE
Add contract statistics feature

### DIFF
--- a/tests/test_contract_stats.py
+++ b/tests/test_contract_stats.py
@@ -1,0 +1,101 @@
+import sys
+from pathlib import Path
+import types
+
+root_dir = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root_dir / 'tool'))
+
+import contract_stats
+
+
+class DummyReceipt:
+    def __init__(self, contract_address=None):
+        self.contractAddress = contract_address
+
+
+class DummyTx:
+    def __init__(self, to=None, tx_hash='0x0'):
+        self.to = to
+        self.hash = tx_hash
+
+
+class DummyBlock:
+    def __init__(self, txs):
+        self.transactions = txs
+
+
+class DummyEth:
+    def __init__(self):
+        self.block_number = 0
+        self._blocks = []
+        self._codes = {}
+        self._balances = {}
+        self._receipts = {}
+
+    def get_block(self, num, full_transactions=False):
+        return self._blocks[num]
+
+    def get_code(self, addr):
+        return self._codes.get(addr, b'')
+
+    def get_balance(self, addr):
+        return self._balances.get(addr, 0)
+
+    def get_transaction_receipt(self, tx_hash):
+        return self._receipts.get(tx_hash, DummyReceipt())
+
+
+class DummyWeb3:
+    def __init__(self):
+        self.eth = DummyEth()
+
+    def is_connected(self):
+        return True
+
+
+def test_collect_contract_addresses():
+    w3 = DummyWeb3()
+    w3.eth.block_number = 1
+
+    tx1 = DummyTx(to='0x1', tx_hash='h1')
+    tx2 = DummyTx(to=None, tx_hash='h2')
+    block0 = DummyBlock([tx1, tx2])
+    block1 = DummyBlock([DummyTx(to='0x1', tx_hash='h3')])
+    w3.eth._blocks = [block0, block1]
+
+    w3.eth._codes['0x1'] = b'abc'
+    w3.eth._codes['0x2'] = b'def'
+    w3.eth._balances['0x1'] = 100
+    w3.eth._balances['0x2'] = 50
+    w3.eth._receipts['h2'] = DummyReceipt('0x2')
+
+    addrs = contract_stats.collect_contract_addresses(w3, 0, 1)
+    assert addrs == {'0x1', '0x2'}
+
+
+def test_count_contracts(monkeypatch):
+    w3 = DummyWeb3()
+    w3.eth.block_number = 0
+    tx = DummyTx(to='0x1', tx_hash='h1')
+    w3.eth._blocks = [DummyBlock([tx])]
+    w3.eth._codes['0x1'] = b'abc'
+    w3.eth._balances['0x1'] = 200
+
+    def fake_provider_url(network):
+        return 'http://example.com'
+
+    class DummyWeb3Class:
+        HTTPProvider = staticmethod(lambda url: None)
+
+        def __new__(cls, provider):
+            return w3
+
+    monkeypatch.setattr(contract_stats, 'get_provider_url', fake_provider_url)
+    monkeypatch.setattr(contract_stats, 'Web3', DummyWeb3Class)
+
+    stats = contract_stats.count_contracts('mainnet', 0, 0)
+    assert stats == {
+        'contract_count': 1,
+        'total_balance_wei': 200,
+        'total_code_size': 3,
+    }

--- a/tool/contract_stats.py
+++ b/tool/contract_stats.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import argparse
+from typing import Iterable, Set
+
+from web3 import Web3
+
+from fetch_and_check import get_provider_url, NETWORK_PROVIDERS
+
+
+def _gather_candidate_addresses(block) -> Iterable[str]:
+    """Yield possible contract addresses from transactions in *block*."""
+    for tx in block.transactions:
+        to_addr = getattr(tx, 'to', None)
+        if to_addr:
+            yield to_addr
+        else:
+            receipt = block.web3.eth.get_transaction_receipt(tx.hash)
+            if receipt and receipt.contractAddress:
+                yield receipt.contractAddress
+
+
+def collect_contract_addresses(w3: Web3, start_block: int = 0, end_block: int | None = None) -> Set[str]:
+    """Return the set of unique contract addresses between the given blocks."""
+    if end_block is None:
+        end_block = w3.eth.block_number
+
+    addresses: Set[str] = set()
+    for num in range(start_block, end_block + 1):
+        block = w3.eth.get_block(num, full_transactions=True)
+        block.web3 = w3  # convenience for _gather_candidate_addresses
+        for addr in _gather_candidate_addresses(block):
+            code = w3.eth.get_code(addr)
+            if code and len(code) > 0:
+                addresses.add(addr)
+    return addresses
+
+
+def count_contracts(network: str, start_block: int = 0, end_block: int | None = None):
+    """Return stats about contracts in the specified block range."""
+    w3 = Web3(Web3.HTTPProvider(get_provider_url(network)))
+    if not w3.is_connected():
+        raise RuntimeError('Web3 provider not available')
+
+    addrs = collect_contract_addresses(w3, start_block, end_block)
+    balance = 0
+    size = 0
+    for a in addrs:
+        balance += w3.eth.get_balance(a)
+        size += len(w3.eth.get_code(a))
+
+    return {
+        'contract_count': len(addrs),
+        'total_balance_wei': balance,
+        'total_code_size': size,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Count contracts on a network')
+    parser.add_argument(
+        '-n', '--network',
+        default='mainnet',
+        choices=sorted(NETWORK_PROVIDERS.keys()),
+        help='Ethereum network to use (default: mainnet)',
+    )
+    parser.add_argument(
+        '--start-block', type=int, default=0,
+        help='block number to start scanning from (default: 0)'
+    )
+    parser.add_argument(
+        '--end-block', type=int, default=None,
+        help='block number to stop scanning at (default: latest)'
+    )
+    args = parser.parse_args()
+
+    stats = count_contracts(args.network, args.start_block, args.end_block)
+    for k, v in stats.items():
+        print(f'{k}: {v}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a new utility `contract_stats.py` to count deployed contracts on a network and gather balance and code size information
- add unit tests for the new functionality

## Testing
- `pip install web3 z3-solver`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f772a89c832da03383cf0b6b907d