### PR TITLE
Add CSV output for contract stats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,3 +17,7 @@ Unique scanning:
   `reports/suicidal.txt`, `reports/prodigal.txt`, and `reports/greedy.txt`.
 
 Any new scripts or modules should include simple unit tests under `tests/` and should avoid network calls during tests by using mocks.
+
+Additional tools:
+- `contract_stats.py` can now save statistics about contracts to a CSV file. Run it with
+  `--output-file <file>` to specify the destination. The default is `contract_stats.csv`.

--- a/tests/test_contract_stats.py
+++ b/tests/test_contract_stats.py
@@ -95,7 +95,30 @@ def test_count_contracts(monkeypatch):
 
     stats = contract_stats.count_contracts('mainnet', 0, 0)
     assert stats == {
+        'network': 'mainnet',
+        'start_block': 0,
+        'end_block': 0,
         'contract_count': 1,
         'total_balance_wei': 200,
         'total_code_size': 3,
     }
+
+
+def test_file_data_store(tmp_path):
+    store_path = tmp_path / 'out.csv'
+    store = contract_stats.FileDataStore(str(store_path))
+    stats = {
+        'network': 'mainnet',
+        'start_block': 0,
+        'end_block': 0,
+        'contract_count': 2,
+        'total_balance_wei': 1000,
+        'total_code_size': 10,
+    }
+    store.save(stats)
+
+    content = store_path.read_text().splitlines()
+    assert content[0].startswith('network,start_block')
+    assert content[1].split(',') == [
+        'mainnet', '0', '0', '2', '1000', '10'
+    ]

--- a/tool/contract_stats.py
+++ b/tool/contract_stats.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import argparse
+import csv
+import os
 from typing import Iterable, Set
 
 from web3 import Web3
@@ -8,14 +10,54 @@ from web3 import Web3
 from fetch_and_check import get_provider_url, NETWORK_PROVIDERS
 
 
-def _gather_candidate_addresses(block) -> Iterable[str]:
+class DataStore:
+    """Abstract storage interface for contract statistics."""
+
+    def save(self, stats: dict) -> None:
+        raise NotImplementedError
+
+
+class FileDataStore(DataStore):
+    """Persist stats to a CSV file."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self._write_header()
+
+    def _write_header(self) -> None:
+        if not os.path.exists(self.path):
+            with open(self.path, 'w', newline='') as fh:
+                writer = csv.writer(fh)
+                writer.writerow([
+                    'network',
+                    'start_block',
+                    'end_block',
+                    'contract_count',
+                    'total_balance_wei',
+                    'total_code_size',
+                ])
+
+    def save(self, stats: dict) -> None:
+        with open(self.path, 'a', newline='') as fh:
+            writer = csv.writer(fh)
+            writer.writerow([
+                stats['network'],
+                stats['start_block'],
+                stats['end_block'],
+                stats['contract_count'],
+                stats['total_balance_wei'],
+                stats['total_code_size'],
+            ])
+
+
+def _gather_candidate_addresses(block, w3: Web3) -> Iterable[str]:
     """Yield possible contract addresses from transactions in *block*."""
     for tx in block.transactions:
         to_addr = getattr(tx, 'to', None)
         if to_addr:
             yield to_addr
         else:
-            receipt = block.web3.eth.get_transaction_receipt(tx.hash)
+            receipt = w3.eth.get_transaction_receipt(tx.hash)
             if receipt and receipt.contractAddress:
                 yield receipt.contractAddress
 
@@ -28,8 +70,7 @@ def collect_contract_addresses(w3: Web3, start_block: int = 0, end_block: int | 
     addresses: Set[str] = set()
     for num in range(start_block, end_block + 1):
         block = w3.eth.get_block(num, full_transactions=True)
-        block.web3 = w3  # convenience for _gather_candidate_addresses
-        for addr in _gather_candidate_addresses(block):
+        for addr in _gather_candidate_addresses(block, w3):
             code = w3.eth.get_code(addr)
             if code and len(code) > 0:
                 addresses.add(addr)
@@ -50,6 +91,9 @@ def count_contracts(network: str, start_block: int = 0, end_block: int | None = 
         size += len(w3.eth.get_code(a))
 
     return {
+        'network': network,
+        'start_block': start_block,
+        'end_block': end_block if end_block is not None else w3.eth.block_number,
         'contract_count': len(addrs),
         'total_balance_wei': balance,
         'total_code_size': size,
@@ -72,11 +116,18 @@ def main() -> None:
         '--end-block', type=int, default=None,
         help='block number to stop scanning at (default: latest)'
     )
+    parser.add_argument(
+        '--output-file', default='contract_stats.csv',
+        help='CSV file to append results to (default: contract_stats.csv)'
+    )
     args = parser.parse_args()
 
     stats = count_contracts(args.network, args.start_block, args.end_block)
     for k, v in stats.items():
         print(f'{k}: {v}')
+
+    store = FileDataStore(args.output_file)
+    store.save(stats)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- fix `contract_stats.py` to work with modern web3 objects
- add `FileDataStore` class and `--output-file` option to persist results in CSV
- expand returned stats to include network and block range
- add unit tests for new functionality
- document new tool behavior in `AGENTS.md`

## Testing
- `pytest -q`
- `python tool/contract_stats.py --network mainnet --start-block 0 --end-block 0 --output-file contract_stats.csv`

------
https://chatgpt.com/codex/tasks/task_e_6862fa1621f0832db2f7d7a05fe4d25e