### PR TITLE
Add dynamic block range option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,5 +19,6 @@ Unique scanning:
 Any new scripts or modules should include simple unit tests under `tests/` and should avoid network calls during tests by using mocks.
 
 Additional tools:
-- `contract_stats.py` can now save statistics about contracts to a CSV file. Run it with
-  `--output-file <file>` to specify the destination. The default is `contract_stats.csv`.
+- `contract_stats.py` can save statistics about contracts to a CSV file. Run it with
+  `--output-file <file>` to specify the destination (default `contract_stats.csv`).
+  Use `--block-range <N>` to count contracts in the last `N` blocks ending at the latest block.

--- a/tests/test_contract_stats.py
+++ b/tests/test_contract_stats.py
@@ -122,3 +122,22 @@ def test_file_data_store(tmp_path):
     assert content[1].split(',') == [
         'mainnet', '0', '0', '2', '1000', '10'
     ]
+
+
+def test_get_current_block_number(monkeypatch):
+    w3 = DummyWeb3()
+    w3.eth.block_number = 42
+
+    def fake_provider_url(network):
+        return 'http://example.com'
+
+    class DummyWeb3Class:
+        HTTPProvider = staticmethod(lambda url: None)
+
+        def __new__(cls, provider):
+            return w3
+
+    monkeypatch.setattr(contract_stats, 'get_provider_url', fake_provider_url)
+    monkeypatch.setattr(contract_stats, 'Web3', DummyWeb3Class)
+
+    assert contract_stats.get_current_block_number('mainnet') == 42


### PR DESCRIPTION
## Summary
- fetch latest block number via `get_current_block_number`
- support `--block-range` CLI argument in `contract_stats.py`
- document new option in `AGENTS.md`
- test the helper retrieving the current block

## Testing
- `pip install web3 z3-solver`
- `pytest -q`
- `python tool/contract_stats.py --block-range 100` *(fails: 403 Client Error)*
- `python tool/contract_stats.py --block-range 1000` *(fails: 403 Client Error)*
- `python tool/contract_stats.py --block-range 10000` *(fails: 403 Client Error)*

------
https://chatgpt.com/codex/tasks/task_e_68630248a328832d922ea11591e7d1fe