### PR TITLE
Add contract downloader utility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,6 @@ Any new scripts or modules should include simple unit tests under `tests/` and s
 Additional tools:
 - `contract_stats.py` can now save statistics about contracts to a CSV file. Run it with
   `--output-file <file>` to specify the destination. The default is `contract_stats.csv`.
+- `contract_downloader.py` fetches bytecode from Etherscan and stores it in
+  `contracts/contracts.jsonl`. Metadata about the stored block range and file
+  size lives in `contracts/metadata.json`.

--- a/tests/test_contract_downloader.py
+++ b/tests/test_contract_downloader.py
@@ -1,0 +1,38 @@
+import json
+from pathlib import Path
+from unittest import mock
+
+import sys
+root_dir = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root_dir / 'tool'))
+import contract_downloader
+
+
+def test_prepend_and_limit(tmp_path):
+    f = tmp_path / 'contracts.jsonl'
+    m = tmp_path / 'meta.json'
+    # set limit small so only one entry kept
+    with mock.patch.object(contract_downloader, 'fetch_contracts', return_value=[{'address':'0x1','bytecode':'aa','block':1}]):
+        with mock.patch.object(contract_downloader, 'get_latest_block', return_value=1):
+            contract_downloader.update_contract_store('k', contract_file=str(f), metadata_file=str(m), size_limit_mb=0.00005, start_block=1, end_block=1)
+    with mock.patch.object(contract_downloader, 'fetch_contracts', return_value=[{'address':'0x2','bytecode':'bb','block':2}]):
+        contract_downloader.update_contract_store('k', contract_file=str(f), metadata_file=str(m), size_limit_mb=0.00005, start_block=2, end_block=2)
+    lines = f.read_text().splitlines()
+    assert json.loads(lines[0])['block'] == 2
+    meta = json.loads(m.read_text())
+    assert meta['newest_block'] == 2
+    assert meta['oldest_block'] == 2
+
+
+def test_get_latest_block(monkeypatch):
+    def fake_get(url, params=None, timeout=10):
+        class R:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {'result': '0x10'}
+        return R()
+    monkeypatch.setattr(contract_downloader.requests, 'get', fake_get)
+    block = contract_downloader.get_latest_block('k')
+    assert block == 16
+

--- a/tool/contract_downloader.py
+++ b/tool/contract_downloader.py
@@ -1,0 +1,110 @@
+import json
+import os
+from pathlib import Path
+from typing import List, Dict
+
+import requests
+
+DEFAULT_LIMIT_MB = 8
+API_URL = "https://api.etherscan.io/api"
+
+
+def load_metadata(path: str | Path) -> Dict:
+    """Return metadata stored in *path* or defaults."""
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    return {
+        "oldest_block": None,
+        "newest_block": None,
+        "size_limit": DEFAULT_LIMIT_MB * 1024 * 1024,
+    }
+
+
+def save_metadata(meta: Dict, path: str | Path) -> None:
+    """Write *meta* dictionary to *path*."""
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(meta, fh)
+
+
+def get_latest_block(api_key: str) -> int:
+    """Return the latest block number according to Etherscan."""
+    params = {"module": "proxy", "action": "eth_blockNumber", "apikey": api_key}
+    resp = requests.get(API_URL, params=params, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    return int(data["result"], 16)
+
+
+def fetch_contracts(api_key: str, start_block: int, end_block: int) -> List[Dict]:
+    """Return contract info between *start_block* and *end_block*."""
+    params = {
+        "module": "contract",
+        "action": "getcontractsbytecode",
+        "startblock": start_block,
+        "endblock": end_block,
+        "page": 1,
+        "offset": 100,
+        "sort": "desc",
+        "apikey": api_key,
+    }
+    resp = requests.get(API_URL, params=params, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    if data.get("status") != "1":
+        return []
+    out = []
+    for item in data.get("result", []):
+        out.append(
+            {
+                "address": item.get("ContractAddress") or item.get("address"),
+                "bytecode": item.get("Bytecode") or item.get("bytecode"),
+                "block": int(item.get("BlockNumber") or item.get("block")),
+            }
+        )
+    return out
+
+
+def _prepend_with_limit(path: Path, lines: List[str], limit: int) -> List[str]:
+    existing = []
+    if path.exists():
+        existing = path.read_text().splitlines(keepends=True)
+    all_lines = lines + existing
+    size = sum(len(l.encode("utf-8")) for l in all_lines)
+    while size > limit and all_lines:
+        removed = all_lines.pop()
+        size -= len(removed.encode("utf-8"))
+    path.write_text("".join(all_lines), encoding="utf-8")
+    return all_lines
+
+
+def update_contract_store(
+    api_key: str,
+    *,
+    contract_file: str = "contracts/contracts.jsonl",
+    metadata_file: str = "contracts/metadata.json",
+    size_limit_mb: float | None = None,
+    start_block: int | None = None,
+    end_block: int | None = None,
+) -> None:
+    """Fetch new contracts and store them prepended in *contract_file*."""
+    meta = load_metadata(metadata_file)
+    if size_limit_mb is not None:
+        meta["size_limit"] = int(size_limit_mb * 1024 * 1024)
+    limit = meta.get("size_limit", DEFAULT_LIMIT_MB * 1024 * 1024)
+    if start_block is None:
+        start_block = (meta.get("newest_block") or 0) + 1
+    if end_block is None:
+        end_block = get_latest_block(api_key)
+    contracts = fetch_contracts(api_key, start_block, end_block)
+    if not contracts:
+        save_metadata(meta, metadata_file)
+        return
+    new_lines = [json.dumps(c) + "\n" for c in contracts]
+    path = Path(contract_file)
+    all_lines = _prepend_with_limit(path, new_lines, limit)
+    if all_lines:
+        blocks = [json.loads(l)["block"] for l in all_lines]
+        meta["newest_block"] = max(blocks)
+        meta["oldest_block"] = min(blocks)
+    save_metadata(meta, metadata_file)


### PR DESCRIPTION
## Summary
- add a `contract_downloader.py` helper to fetch contract bytecode from Etherscan
- track stored contract metadata and size limit
- include a `.gitkeep` for the contracts directory
- test the downloader logic with mocks
- document the new tool in AGENTS.md

## Testing
- `pip install web3 z3-solver`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68630340ff64832d9f2038b35f5effe9