### PR TITLE
Add Docker support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,6 @@ Additional tools:
   `contracts/contracts.jsonl`. Metadata about the stored block range and file
   size lives in `contracts/metadata.json`.
 
+- A `Dockerfile` in the repository root can build a container with all
+  dependencies installed. Build it using `docker build -t maian .`.
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.8-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends software-properties-common ca-certificates wget && \
+    add-apt-repository -y ppa:ethereum/ethereum && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends geth solc && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /maian
+
+COPY . /maian
+
+RUN pip install --no-cache-dir web3 z3-solver
+
+CMD ["python", "tool/maian.py", "-h"]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ systems). The tool additionally relies on the following external software:
 2. Solidity compiler – <https://docs.soliditylang.org/en/latest/installing-solidity.html>
 3. Z3 Theorem prover – <https://github.com/Z3Prover/z3>
 
+### Docker
+
+A `Dockerfile` is provided to build an isolated environment with all
+dependencies preinstalled. From the repository root run:
+
+```bash
+docker build -t maian .
+```
+
+After building, the tool can be executed with:
+
+```bash
+docker run --rm maian python tool/maian.py -h
+```
+
 ### Running Maian
 
 From the repository root you can analyze a contract using:


### PR DESCRIPTION
## Summary
- provide a Dockerfile for a reproducible environment
- document Docker usage in README
- mention Docker helper in AGENTS guidelines

## Testing
- `pip install web3 z3-solver`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863105f85e4832d968a9b914a3a05c8