### PR TITLE
Fix bytecode extraction

### DIFF
--- a/tests/test_fetch_and_check_extra.py
+++ b/tests/test_fetch_and_check_extra.py
@@ -23,7 +23,7 @@ def test_fetch_contract_bytecode_returns_hex():
     address = '0xabc'
     w3.codes[address] = b'\x01\x02'
     result = fetch_and_check.fetch_contract_bytecode(w3, address)
-    assert result == "02"
+    assert result == "0102"
 
 
 def test_random_contract_address_error():

--- a/tool/contract_downloader.py
+++ b/tool/contract_downloader.py
@@ -112,7 +112,7 @@ class RPCSource(DataSource):
                     contracts.append(
                         {
                             "address": addr,
-                            "bytecode": code.hex()[2:],
+                            "bytecode": code.hex(),
                             "block": num,
                         }
                     )

--- a/tool/fetch_and_check.py
+++ b/tool/fetch_and_check.py
@@ -41,8 +41,9 @@ def random_contract_address(w3, search_depth=1000, attempts=20):
 
 
 def fetch_contract_bytecode(w3, address):
+    """Return bytecode for ``address`` as a hex string without the ``0x`` prefix."""
     code = w3.eth.get_code(address)
-    return code.hex()[2:]
+    return code.hex()
 
 
 def run_checks(bytecode, address):


### PR DESCRIPTION
## Summary
- ensure RPC downloader stores full bytecode instead of trimming
- update helper function to return full bytecode
- adjust corresponding unit test

## Testing
- `pip install web3 z3-solver`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68635c8243f4832d9bb31df3c6bca86d