### PR TITLE
Add BigQuery data getter

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ results in ``contracts/EtherscanVerified.jsonl``; otherwise contracts are stored
 in ``contracts/contracts.jsonl`` together with a metadata file describing the
 covered block range.
 
+### Using BigQuery
+
+Contract bytecode can also be loaded from Google BigQuery. Create a free GCP
+Sandbox project and enable the BigQuery API. Install the additional dependency
+with ``pip install -r requirements-bigquery.txt``. The ``DataGetterBigQuery``
+class pulls data from ``bigquery-public-data.crypto_ethereum.contracts`` using
+the free tier (up to 1&nbsp;TB/month of processed data). Provide credentials via
+``GOOGLE_APPLICATION_CREDENTIALS`` and choose a small block window to keep the
+queried data under the free limit.
+
 ## Installation
 
 Maian requires Python 3.8 or newer. Install the Python dependencies using:

--- a/requirements-bigquery.txt
+++ b/requirements-bigquery.txt
@@ -1,0 +1,1 @@
+google-cloud-bigquery>=3.20.0

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,5 @@
+"""MAIAN data modules."""
+
+from .data_getters import DataGetterBigQuery, DataGetter
+
+__all__ = ["DataGetter", "DataGetterBigQuery"]

--- a/src/data_getters/__init__.py
+++ b/src/data_getters/__init__.py
@@ -1,0 +1,5 @@
+"""Data acquisition helpers."""
+
+from .bigquery_getter import DataGetter, DataGetterBigQuery
+
+__all__ = ["DataGetter", "DataGetterBigQuery"]

--- a/src/data_getters/bigquery_getter.py
+++ b/src/data_getters/bigquery_getter.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import time
+from typing import Iterable, List, Tuple, Optional
+
+from google.cloud import bigquery
+from google.api_core.exceptions import BadRequest, GoogleAPICallError
+
+
+class DataGetter:
+    """Base class for data getters."""
+
+    def fetch_chunk(self, start_block: int, end_block: int) -> Iterable[List[Tuple[str, str]]]:
+        raise NotImplementedError
+
+
+class DataGetterBigQuery(DataGetter):
+    """Fetch contract bytecodes from the public BigQuery Ethereum dataset."""
+
+    _SQL = (
+        """
+        SELECT ANY_VALUE(address) AS address, bytecode
+        FROM `bigquery-public-data.crypto_ethereum.contracts`
+        WHERE block_number BETWEEN @start AND @end
+          AND BYTE_LENGTH(bytecode) > 2000
+          AND NOT REGEXP_CONTAINS(bytecode, r"^0x363d3d373d3d3d363d73|^0x3660008037600080")
+        GROUP BY bytecode
+        """
+    )
+
+    def __init__(self, page_rows: int = 20_000) -> None:
+        self._client = bigquery.Client()
+        self._page_rows = page_rows
+        self._last_job: Optional[bigquery.job.QueryJob] = None
+
+    @property
+    def last_job(self) -> Optional[bigquery.job.QueryJob]:
+        """Return the last executed BigQuery job."""
+        return self._last_job
+
+    def _run_query(self, job_config: bigquery.QueryJobConfig) -> bigquery.job.QueryJob:
+        delay = 2.0
+        exc: Optional[Exception] = None
+        for _ in range(5):
+            try:
+                job = self._client.query(self._SQL, job_config=job_config)
+                return job
+            except (BadRequest, GoogleAPICallError) as e:  # pragma: no cover - network
+                exc = e
+                time.sleep(delay)
+                delay *= 2
+        assert exc is not None
+        raise exc
+
+    def fetch_chunk(self, start_block: int, end_block: int) -> Iterable[List[Tuple[str, str]]]:
+        job_config = bigquery.QueryJobConfig(
+            query_parameters=[
+                bigquery.ScalarQueryParameter("start", "INT64", start_block),
+                bigquery.ScalarQueryParameter("end", "INT64", end_block),
+            ]
+        )
+        job = self._run_query(job_config)
+        self._last_job = job
+
+        for page in job.result(page_size=self._page_rows).pages:
+            yield [(r.address, r.bytecode) for r in page]

--- a/tests/test_bigquery_getter.py
+++ b/tests/test_bigquery_getter.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+root_dir = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root_dir / 'src'))
+
+from data_getters import DataGetterBigQuery
+
+PROXY_PREFIXES = (
+    "0x363d3d373d3d3d363d73",
+    "0x3660008037600080",
+)
+
+
+def _has_creds() -> bool:
+    try:
+        DataGetterBigQuery()
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _has_creds(), reason="No GCP credentials")
+def test_bigquery_basic():
+    start = 17000000
+    end = start + 20
+    getter = DataGetterBigQuery(page_rows=1000)
+    pages = list(getter.fetch_chunk(start, end))
+    rows = [row for page in pages for row in page]
+    assert rows
+    assert getter.last_job.total_bytes_processed < 1_000_000_000
+    for _, code in rows:
+        assert not code.startswith(PROXY_PREFIXES)


### PR DESCRIPTION
## Summary
- add `DataGetterBigQuery` for pulling contract bytecodes via BigQuery
- expose new getter through package `__init__`
- document BigQuery usage in README
- supply bigquery requirements file
- test that BigQuery fetching works (skips without credentials)

## Testing
- `pip install web3 z3-solver google-cloud-bigquery>=3.20.0`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686366133fec832db1c121ba2c07d9b0