### PR TITLE
Add AWS Open Data Parquet getter

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,26 @@ key set the ``BIGQUERY_API_KEY`` environment variable and provide your project
 ID via ``BIGQUERY_PROJECT_ID`` or the constructor. Always choose a small block
 window to keep the queried data under the free limit.
 
+### Using AWS Open Data
+
+Contract bytecode is also available through the AWS Open-Data program as
+Parquet dumps. The ``DataGetterAWSParquet`` helper reads these files from a
+local directory or an S3 bucket. Install ``pyarrow`` and point the getter to
+the dataset path:
+
+```bash
+pip install pyarrow
+```
+
+```python
+from data_getters import DataGetterAWSParquet
+
+getter = DataGetterAWSParquet("s3://bucket/path")
+for page in getter.fetch_chunk(100000, 100100):
+    for address, bytecode in page:
+        print(address, len(bytecode))
+```
+
 ## Installation
 
 Maian requires Python 3.8 or newer. Install the Python dependencies using:

--- a/reports/aws_parquet_test_report.md
+++ b/reports/aws_parquet_test_report.md
@@ -1,0 +1,7 @@
+# AWS Open Data Parquet Test Report
+
+The new `DataGetterAWSParquet` class loads contract bytecode from Parquet files.
+A small sample file was generated locally for testing. The getter returned the
+expected address/bytecode pairs for the requested block range. Access to the
+actual AWS Open-Data S3 buckets was blocked in this environment, so full-scale
+retrieval could not be demonstrated.

--- a/src/data_getters/__init__.py
+++ b/src/data_getters/__init__.py
@@ -1,5 +1,6 @@
 """Data acquisition helpers."""
 
 from .bigquery_getter import DataGetter, DataGetterBigQuery
+from .aws_parquet_getter import DataGetterAWSParquet
 
-__all__ = ["DataGetter", "DataGetterBigQuery"]
+__all__ = ["DataGetter", "DataGetterBigQuery", "DataGetterAWSParquet"]

--- a/src/data_getters/aws_parquet_getter.py
+++ b/src/data_getters/aws_parquet_getter.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Iterable, List, Tuple
+
+import pyarrow.dataset as ds
+
+from .bigquery_getter import DataGetter
+
+
+class DataGetterAWSParquet(DataGetter):
+    """Load contract data from AWS Open-Data Parquet dumps.
+
+    The dataset must contain ``address``, ``bytecode`` and ``block_number``
+    columns. ``path`` can point to a local directory or an S3 bucket
+    (e.g. ``s3://...``). Results are yielded in pages of ``page_rows``
+    tuples ``(address, bytecode)``.
+    """
+
+    def __init__(self, path: str, page_rows: int = 20_000) -> None:
+        self._dataset = ds.dataset(path, format="parquet")
+        self._page_rows = page_rows
+
+    def fetch_chunk(self, start_block: int, end_block: int) -> Iterable[List[Tuple[str, str]]]:
+        filt = (
+            (ds.field("block_number") >= start_block)
+            & (ds.field("block_number") <= end_block)
+        )
+        table = self._dataset.to_table(filter=filt)
+        rows = list(zip(table["address"].to_pylist(), table["bytecode"].to_pylist()))
+        for i in range(0, len(rows), self._page_rows):
+            yield rows[i : i + self._page_rows]

--- a/src/data_getters/bigquery_getter.py
+++ b/src/data_getters/bigquery_getter.py
@@ -43,6 +43,8 @@ class DataGetterBigQuery(DataGetter):
         key instead of ``GOOGLE_APPLICATION_CREDENTIALS``. If omitted, the
         default credentials flow is used.
         """
+        if os.getenv("DISABLE_BIGQUERY") and api_key is None:
+            raise RuntimeError("BigQuery disabled")
         if api_key is None:
             api_key = os.getenv("BIGQUERY_API_KEY")
         if project_id is None:

--- a/tests/test_aws_parquet_getter.py
+++ b/tests/test_aws_parquet_getter.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+import sys
+root_dir = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root_dir / 'src'))
+
+from data_getters import DataGetterAWSParquet
+
+
+def _make_sample(path: Path) -> None:
+    table = pa.table({
+        'block_number': [1, 2, 3, 4],
+        'address': ['0x1', '0x2', '0x3', '0x4'],
+        'bytecode': ['aa', 'bb', 'cc', 'dd'],
+    })
+    pq.write_table(table, path)
+
+
+def test_parquet_getter_basic(tmp_path):
+    f = tmp_path / 'data.parquet'
+    _make_sample(f)
+    g = DataGetterAWSParquet(str(f), page_rows=2)
+    pages = list(g.fetch_chunk(2, 3))
+    rows = [r for page in pages for r in page]
+    assert rows == [('0x2', 'bb'), ('0x3', 'cc')]


### PR DESCRIPTION
## Summary
- add `DataGetterAWSParquet` for loading Parquet dumps
- expose the new getter in `data_getters` package
- let BigQuery getter disable itself in CI
- document AWS Open Data usage in README
- test Parquet getter
- record results in a short report

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686404b44408832dbc5e2b0df37171af