### PR TITLE
Format AWS Parquet getter output

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ from data_getters import DataGetterAWSParquet
 
 getter = DataGetterAWSParquet("s3://bucket/path")
 for page in getter.fetch_chunk(100000, 100100):
-    for address, bytecode, block in page:
-        print(address, block)
+    for row in page:
+        print(row["Address"], row["BlockNumber"])
 ```
 
 ## Installation

--- a/docs/data_download_flow.md
+++ b/docs/data_download_flow.md
@@ -16,8 +16,9 @@ contract store.
 3. **Fetch contracts** – the chosen `DataSource` retrieves contract dictionaries
    using its `fetch` method. The provided `ParquetSource` relies on
    `DataGetterAWSParquet` to read data from a Parquet dataset (local or S3).
-4. **Validate data** – each returned contract must contain an address, bytecode
-   and the block number. Invalid entries raise an assertion error.
+4. **Validate data** – each returned contract must contain ``Address``,
+   ``ByteCode`` and ``BlockNumber`` fields. Invalid entries raise an assertion
+   error.
 5. **Write to file** – new contracts are prepended to
    `contracts/contracts.jsonl` using `_prepend_with_limit`, which enforces the
    configured size limit and verifies that all JSON lines remain intact.
@@ -37,7 +38,7 @@ flowchart TD
     defaultRange --> fetch
     fetch["source.fetch"] --> getter["DataGetterAWSParquet"]
     getter --> dataset[("Parquet data")]
-    fetch --> validate["check address/bytecode"]
+    fetch --> validate["check Address/ByteCode/BlockNumber"]
     validate --> prepend["_prepend_with_limit"]
     prepend --> upd["update block metadata"]
     upd --> save["save files"]

--- a/reports/aws_parquet_test_report.md
+++ b/reports/aws_parquet_test_report.md
@@ -2,6 +2,7 @@
 
 The new `DataGetterAWSParquet` class loads contract bytecode from Parquet files.
 A small sample file was generated locally for testing. The getter returned the
-expected address/bytecode pairs for the requested block range. Access to the
+expected dictionaries with ``Address``, ``ByteCode`` and ``BlockNumber`` fields
+for the requested block range. Access to the
 actual AWS Open-Data S3 buckets was blocked in this environment, so full-scale
 retrieval could not be demonstrated.

--- a/tests/test_aws_parquet_getter.py
+++ b/tests/test_aws_parquet_getter.py
@@ -24,4 +24,7 @@ def test_parquet_getter_basic(tmp_path):
     g = DataGetterAWSParquet(str(f), page_rows=2)
     pages = list(g.fetch_chunk(2, 3))
     rows = [r for page in pages for r in page]
-    assert rows == [('0x2', 'bb', 2), ('0x3', 'cc', 3)]
+    assert rows == [
+        {"Address": "0x2", "ByteCode": "bb", "BlockNumber": 2},
+        {"Address": "0x3", "ByteCode": "cc", "BlockNumber": 3},
+    ]

--- a/tool/contract_downloader.py
+++ b/tool/contract_downloader.py
@@ -36,8 +36,12 @@ class ParquetSource(DataSource):
     def fetch(self, start_block: int, end_block: int) -> List[Dict]:
         contracts = []
         for page in self._getter.fetch_chunk(start_block, end_block):
-            for addr, code, blk in page:
-                contracts.append({"address": addr, "bytecode": code, "block": blk})
+            for row in page:
+                contracts.append({
+                    "address": row["Address"],
+                    "bytecode": row["ByteCode"],
+                    "block": row["BlockNumber"],
+                })
         return contracts
 
 

--- a/tool/data_getters/aws_parquet_getter.py
+++ b/tool/data_getters/aws_parquet_getter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable, List, Tuple
+from typing import Any, Dict, Iterable, List
 
 import pyarrow.dataset as ds
 
@@ -13,7 +13,7 @@ class DataGetterAWSParquet(DataGetter):
     The dataset must contain ``address``, ``bytecode`` and ``block_number``
     columns. ``path`` can point to a local directory or an S3 bucket
     (e.g. ``s3://...``). Results are yielded in pages of ``page_rows``
-    tuples ``(address, bytecode, block_number)``.
+    dictionaries with ``Address``, ``ByteCode`` and ``BlockNumber`` fields.
     """
 
     def __init__(self, path: str, page_rows: int = 20_000) -> None:
@@ -22,18 +22,23 @@ class DataGetterAWSParquet(DataGetter):
 
     def fetch_chunk(
         self, start_block: int, end_block: int
-    ) -> Iterable[List[Tuple[str, str, int]]]:
+    ) -> Iterable[List[Dict[str, Any]]]:
         filt = (
             (ds.field("block_number") >= start_block)
             & (ds.field("block_number") <= end_block)
         )
         table = self._dataset.to_table(filter=filt)
-        rows = list(
-            zip(
+        rows = [
+            {
+                "Address": addr,
+                "ByteCode": code,
+                "BlockNumber": blk,
+            }
+            for addr, code, blk in zip(
                 table["address"].to_pylist(),
                 table["bytecode"].to_pylist(),
                 table["block_number"].to_pylist(),
             )
-        )
+        ]
         for i in range(0, len(rows), self._page_rows):
             yield rows[i : i + self._page_rows]

--- a/tool/data_getters/base.py
+++ b/tool/data_getters/base.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
-from typing import Iterable, List, Tuple
+from typing import Any, Dict, Iterable, List
 
 class DataGetter:
     """Base class for data getters."""
 
-    def fetch_chunk(self, start_block: int, end_block: int) -> Iterable[List[Tuple[str, str]]]:
-        """Return an iterable of pages containing `(address, bytecode)` tuples."""
+    def fetch_chunk(self, start_block: int, end_block: int) -> Iterable[List[Dict[str, Any]]]:
+        """Yield pages of contract dictionaries.
+
+        Each dictionary contains the ``Address``, ``ByteCode`` and
+        ``BlockNumber`` fields.
+        """
         raise NotImplementedError


### PR DESCRIPTION
## Summary
- update base getter interface to return dictionaries
- change AWS Parquet getter to yield dictionaries with Address/ByteCode/BlockNumber
- adjust ParquetSource fetch logic
- revise docs, README and report wording
- update unit tests for new format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68644770e86c832da9240f42e766a9ab