### PR TITLE
Add SQLite contract downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ with a metadata file describing the covered block range.
 The full download logic is explained in
 [`docs/data_download_flow.md`](docs/data_download_flow.md).
 
+### SQLite Contract Store
+
+`contract_sqlite_loader.py` can store contract bytecode in a SQLite database.
+The tool keeps track of the scanned block range in a `meta` table and enforces
+a configurable size limit (40 MB by default).
+
+```
+python tool/contract_sqlite_loader.py <dataset> contracts.db
+```
+
+Use `--once` to fetch a single batch instead of running continuously.
+
 ### Using AWS Open Data
 
 Contract bytecode is also available through the AWS Open-Data program as

--- a/tests/test_contract_sqlite_loader.py
+++ b/tests/test_contract_sqlite_loader.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+import sqlite3
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+import sys
+root_dir = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root_dir / 'tool'))
+
+import contract_sqlite_loader as loader
+
+
+def _make_dataset(path: Path) -> None:
+    table = pa.table({
+        'block_number': [1, 2, 3],
+        'address': ['0x1', '0x2', '0x3'],
+        'bytecode': ['aa', 'bb', 'cc'],
+    })
+    pq.write_table(table, path)
+
+
+def test_update_contract_db_basic(tmp_path):
+    data = tmp_path / 'data.parquet'
+    _make_dataset(data)
+    db = tmp_path / 'out.db'
+    loader.update_contract_db(str(data), str(db), start_block=2, end_block=3)
+    conn = sqlite3.connect(db)
+    rows = list(conn.execute('SELECT address, bytecode, block_number FROM contracts ORDER BY block_number'))
+    conn.close()
+    assert rows == [
+        ('0x2', 'bb', 2),
+        ('0x3', 'cc', 3),
+    ]
+    conn = sqlite3.connect(db)
+    meta = {k: v for k, v in conn.execute('SELECT key, value FROM meta')}
+    conn.close()
+    assert meta['newest_block'] == '3'
+    assert meta['oldest_block'] == '2'
+
+
+def test_update_contract_db_default_latest(tmp_path):
+    data = tmp_path / 'data.parquet'
+    _make_dataset(data)
+    db = tmp_path / 'out.db'
+    loader.update_contract_db(str(data), str(db))
+    conn = sqlite3.connect(db)
+    rows = list(conn.execute('SELECT block_number FROM contracts'))
+    meta = {k: v for k, v in conn.execute('SELECT key, value FROM meta')}
+    conn.close()
+    assert [r[0] for r in rows] == [3]
+    assert meta['newest_block'] == '3'
+    assert meta['oldest_block'] == '3'
+
+
+def test_size_limit_enforced(tmp_path):
+    data = tmp_path / 'data.parquet'
+    table = pa.table({
+        'block_number': [1, 2, 3, 4],
+        'address': ['0x1', '0x2', '0x3', '0x4'],
+        'bytecode': ['aa', 'bb', 'cc', 'dd'],
+    })
+    pq.write_table(table, data)
+
+    db = tmp_path / 'out.db'
+    # tiny limit so not all rows fit
+    loader.update_contract_db(str(data), str(db), size_limit_mb=0.0001, start_block=1, end_block=4)
+    conn = sqlite3.connect(db)
+    row_count = conn.execute('SELECT COUNT(*) FROM contracts').fetchone()[0]
+    conn.close()
+    assert row_count < 4

--- a/tool/contract_sqlite_loader.py
+++ b/tool/contract_sqlite_loader.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import time
+from typing import Dict, Optional
+
+import pyarrow.dataset as ds
+
+from data_getters import DataGetterAWSParquet
+
+DEFAULT_LIMIT_MB = 40
+
+
+def _latest_block(path: str) -> int:
+    """Return the highest block number in the Parquet dataset."""
+    dataset = ds.dataset(path, format="parquet")
+    table = dataset.to_table(columns=["block_number"])
+    return max(table["block_number"].to_pylist())
+
+
+def _init_db(conn: sqlite3.Connection, size_limit: int) -> None:
+    """Create tables if they do not exist and store size limit."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS contracts (
+            address TEXT PRIMARY KEY,
+            bytecode TEXT NOT NULL,
+            block_number INTEGER NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS meta (
+            key TEXT PRIMARY KEY,
+            value TEXT
+        )
+        """
+    )
+    cur = conn.execute("SELECT value FROM meta WHERE key='size_limit'")
+    row = cur.fetchone()
+    if row is None:
+        conn.execute(
+            "INSERT INTO meta(key, value) VALUES('size_limit', ?)",
+            (str(size_limit),),
+        )
+        conn.commit()
+
+
+def _load_meta(conn: sqlite3.Connection) -> Dict[str, str]:
+    cur = conn.execute("SELECT key, value FROM meta")
+    return {k: v for k, v in cur.fetchall()}
+
+
+def _save_meta(conn: sqlite3.Connection, meta: Dict[str, str]) -> None:
+    for k, v in meta.items():
+        conn.execute(
+            "INSERT OR REPLACE INTO meta(key, value) VALUES(?, ?)",
+            (k, str(v)),
+        )
+    conn.commit()
+
+
+def update_contract_db(
+    parquet_path: str,
+    db_path: str,
+    *,
+    size_limit_mb: Optional[float] = None,
+    start_block: Optional[int] = None,
+    end_block: Optional[int] = None,
+    page_rows: int = 2000,
+) -> bool:
+    """Fetch new contracts from *parquet_path* and store them in *db_path*.
+
+    Returns ``True`` if new rows were inserted.
+    """
+    limit = int((size_limit_mb or DEFAULT_LIMIT_MB) * 1024 * 1024)
+    conn = sqlite3.connect(db_path)
+    try:
+        _init_db(conn, limit)
+        meta = _load_meta(conn)
+        if size_limit_mb is not None and meta.get("size_limit") != str(limit):
+            meta["size_limit"] = str(limit)
+        newest = int(meta.get("newest_block", -1)) if meta.get("newest_block") else None
+        oldest = int(meta.get("oldest_block", -1)) if meta.get("oldest_block") else None
+
+        getter = DataGetterAWSParquet(parquet_path, page_rows=page_rows)
+        latest = _latest_block(parquet_path)
+
+        if start_block is None and end_block is None:
+            if newest is None:
+                start_block = latest
+                end_block = latest
+            else:
+                start_block = newest + 1
+                end_block = latest
+        elif start_block is None:
+            start_block = end_block
+        elif end_block is None:
+            end_block = start_block
+
+        if newest is not None and start_block <= newest <= end_block:
+            start_block = newest + 1
+        if oldest is not None and start_block <= oldest <= end_block:
+            end_block = oldest - 1
+        if start_block > end_block:
+            _save_meta(conn, meta)
+            return False
+
+        inserted = False
+        for page in getter.fetch_chunk(start_block, end_block):
+            for r in page:
+                conn.execute(
+                    "INSERT OR IGNORE INTO contracts(address, bytecode, block_number) VALUES(?, ?, ?)",
+                    (r["Address"], r["ByteCode"], r["BlockNumber"]),
+                )
+                conn.commit()
+                inserted = True
+                if os.path.getsize(db_path) >= limit:
+                    break
+            if os.path.getsize(db_path) >= limit:
+                break
+        if inserted:
+            cur = conn.execute("SELECT MAX(block_number), MIN(block_number) FROM contracts")
+            newest_db, oldest_db = cur.fetchone()
+            meta["newest_block"] = str(newest_db)
+            meta["oldest_block"] = str(oldest_db)
+        _save_meta(conn, meta)
+        return inserted
+    finally:
+        conn.close()
+
+
+def run_continuous(
+    parquet_path: str,
+    db_path: str,
+    *,
+    interval: float = 5.0,
+    page_rows: int = 2000,
+    size_limit_mb: float = DEFAULT_LIMIT_MB,
+) -> None:
+    """Continuously update the database until the size limit is reached."""
+    while True:
+        if os.path.exists(db_path) and os.path.getsize(db_path) >= size_limit_mb * 1024 * 1024:
+            break
+        inserted = update_contract_db(
+            parquet_path,
+            db_path,
+            size_limit_mb=size_limit_mb,
+            page_rows=page_rows,
+        )
+        if not inserted:
+            break
+        if os.path.getsize(db_path) >= size_limit_mb * 1024 * 1024:
+            break
+        time.sleep(interval)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Store contract data in SQLite")
+    parser.add_argument("parquet", help="Path to Parquet dataset")
+    parser.add_argument("db", help="SQLite database file")
+    parser.add_argument("--page-rows", type=int, default=2000, help="rows per fetch chunk")
+    parser.add_argument("--interval", type=float, default=5.0, help="poll interval for continuous mode")
+    parser.add_argument("--size-limit", type=float, default=DEFAULT_LIMIT_MB, help="database size limit in MB")
+    parser.add_argument("--once", action="store_true", help="run a single update instead of continuous mode")
+    args = parser.parse_args()
+
+    if args.once:
+        update_contract_db(
+            args.parquet,
+            args.db,
+            size_limit_mb=args.size_limit,
+            page_rows=args.page_rows,
+        )
+    else:
+        run_continuous(
+            args.parquet,
+            args.db,
+            interval=args.interval,
+            page_rows=args.page_rows,
+            size_limit_mb=args.size_limit,
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `contract_sqlite_loader.py` to save contract bytecode into SQLite
- document the new tool in the README
- add unit tests for the SQLite loader

## Testing
- `pip install web3 z3-solver pyarrow`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68644e42dfac832d9b6af8455ee8be7d