### PR TITLE
Add SQLite DB head viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ python tool/contract_sqlite_loader.py /path/to/parquet contracts.db
 
 Use `--once` to fetch a single batch instead of running continuously.
 
+### Viewing Database Entries
+
+The `db_head.py` helper prints the first few rows stored in the SQLite database.
+
+```
+python tool/db_head.py contracts.db --count 3
+```
+
+
 ### Using AWS Open Data
 
 Contract bytecode is also available through the AWS Open-Data program as

--- a/tests/test_db_head.py
+++ b/tests/test_db_head.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+import sqlite3
+import sys
+
+root_dir = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root_dir / 'tool'))
+
+import db_head
+
+
+def _make_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE contracts (
+            address TEXT PRIMARY KEY,
+            bytecode TEXT NOT NULL,
+            block_number INTEGER NOT NULL
+        )
+        """
+    )
+    rows = [
+        ('0x1', 'aa', 1),
+        ('0x2', 'bb', 2),
+        ('0x3', 'cc', 3),
+    ]
+    conn.executemany(
+        'INSERT INTO contracts(address, bytecode, block_number) VALUES(?, ?, ?)',
+        rows,
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_get_entries(tmp_path):
+    db = tmp_path / 'c.db'
+    _make_db(db)
+    rows = db_head.get_entries(str(db), limit=2)
+    assert rows == [
+        ('0x1', 'aa', 1),
+        ('0x2', 'bb', 2),
+    ]
+
+
+def test_cli(monkeypatch, tmp_path, capsys):
+    db = tmp_path / 'c.db'
+    _make_db(db)
+    monkeypatch.setattr(sys, 'argv', ['db_head.py', str(db), '--count', '1'])
+    db_head.main()
+    out = capsys.readouterr().out
+    assert '0x1' in out

--- a/tool/db_head.py
+++ b/tool/db_head.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from typing import List, Tuple
+
+
+def get_entries(db_path: str, limit: int = 5) -> List[Tuple[str, str, int]]:
+    """Return the first *limit* rows from the contracts table."""
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.execute(
+            "SELECT address, bytecode, block_number FROM contracts "
+            "ORDER BY block_number LIMIT ?",
+            (limit,),
+        )
+        return cur.fetchall()
+    finally:
+        conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Show first rows of a contract DB")
+    parser.add_argument("db", help="SQLite database file")
+    parser.add_argument("--count", type=int, default=5,
+                        help="number of rows to display (default: 5)")
+    args = parser.parse_args()
+    rows = get_entries(args.db, args.count)
+    for address, bytecode, block in rows:
+        snippet = bytecode[:20] + ("..." if len(bytecode) > 20 else "")
+        print(f"{block:>10}  {address}  {snippet}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a small utility `db_head.py` to print first entries from the contracts database
- document database viewing helper in README
- test getting entries and CLI behavior

## Testing
- `pip install web3 z3-solver`
- `pip install pyarrow`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68645e2e2800832d91829ec2563e4d88