### PR TITLE
Add progress callback and GUI option for SQLite loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,16 +74,17 @@ Provide a custom dataset path as the first argument if needed:
 python tool/contract_sqlite_loader.py /path/to/parquet contracts.db
 ```
 
-Use `--once` to fetch a single batch instead of running continuously.
+Use `--once` to fetch a single batch instead of running continuously. Progress
+messages are printed to the console while the loader runs.
 
 ### Minimal Loader GUI
 
-``sql_gui.py`` offers a very small Tkinter based interface for
-``contract_sqlite_loader.py``. It shows the current block range stored in the
-database and lets you stop the loader.
+``contract_sqlite_loader.py`` also supports a simple Tkinter GUI via the
+``--gui`` flag. The interface shows the current block range stored in the
+database and logs progress to the console.
 
 ```bash
-python tool/sql_gui.py contracts.db
+python tool/contract_sqlite_loader.py --gui contracts.db
 ```
 
 ### Viewing Database Entries

--- a/tests/test_contract_sqlite_loader.py
+++ b/tests/test_contract_sqlite_loader.py
@@ -160,3 +160,16 @@ def test_run_continuous_until_stops_on_event(tmp_path):
     count = conn.execute("SELECT COUNT(*) FROM contracts").fetchone()[0]
     conn.close()
     assert count > 0
+
+
+def test_progress_callback_invoked(tmp_path):
+    data = tmp_path / "data.parquet"
+    _make_dataset(data)
+    db = tmp_path / "out.db"
+    calls: list[str] = []
+
+    def cb(msg: str) -> None:
+        calls.append(msg)
+
+    loader.update_contract_db(str(data), str(db), progress_cb=cb)
+    assert calls

--- a/tool/sql_gui.py
+++ b/tool/sql_gui.py
@@ -28,11 +28,14 @@ class LoaderApp(tk.Tk):
         self.protocol("WM_DELETE_WINDOW", self._kill)
         self.after(100, self._start)
 
+    def _log(self, msg: str) -> None:
+        print(msg)
+
     def _start(self) -> None:
         self.thread = threading.Thread(
             target=run_continuous_until,
             args=(self.parquet_path, self.db_path, self.stop_event),
-            kwargs={"interval": self.interval},
+            kwargs={"interval": self.interval, "progress_cb": self._log},
             daemon=True,
         )
         self.thread.start()
@@ -49,9 +52,13 @@ class LoaderApp(tk.Tk):
             newest = meta.get("newest_block")
             oldest = meta.get("oldest_block")
             if newest and oldest:
-                self.label_var.set(f"Blocks {oldest}-{newest}")
+                msg = f"Blocks {oldest}-{newest}"
+                self.label_var.set(msg)
+                self._log(msg)
             else:
-                self.label_var.set("Waiting for blocks...")
+                msg = "Waiting for blocks..."
+                self.label_var.set(msg)
+                self._log(msg)
         if not self.stop_event.is_set():
             self.after(1000, self._update_status)
 


### PR DESCRIPTION
## Summary
- integrate SQL loader GUI with the main loader via `--gui`
- print progress messages while loading contracts
- support optional progress callbacks
- update docs for new behaviour
- test progress callback functionality

## Testing
- `pip install web3 z3-solver`
- `pip install pyarrow`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864789b87a0832dac34fdd3133c5c8f