### PR TITLE
Add reverse contract loader tool with GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,19 @@ the database and logs progress to the console. Press ``q`` to exit.
 python tool/contract_sqlite_loader.py --gui contracts.db
 ```
 
+### Reverse Loader
+
+`contract_sqlite_descender.py` is a simplified variant that works
+backwards from the latest block, keeping only the most recent rows
+until a size limit is reached. The script exposes flags for the output
+database, size limit and chunk size:
+
+```bash
+python tool/contract_sqlite_descender.py --db contracts.db --size-limit 40 --page-rows 1000
+```
+
+Use `--gui` to display the lowest processed block in a tiny curses UI.
+
 ### Viewing Database Entries
 
 The `db_head.py` helper prints the first few rows stored in the SQLite database.

--- a/reports/descender_report.md
+++ b/reports/descender_report.md
@@ -1,0 +1,13 @@
+# Contract SQLite Descender
+
+A minimal loader (`contract_sqlite_descender.py`) was added. It downloads
+contract data starting from the newest block and works backwards until the
+SQLite database reaches a user specified size. The script supports flags for
+selecting the database name (`--db`), the size limit in megabytes
+(`--size-limit`) and how many rows to fetch per chunk (`--page-rows`).
+
+A tiny curses GUI is available via `--gui`; it shows the lowest processed block
+as the loader runs.
+
+Unit tests verify reverse insertion order and that the CLI uses the default
+Parquet dataset when started with the GUI flag.

--- a/tests/test_contract_sqlite_descender.py
+++ b/tests/test_contract_sqlite_descender.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+import sqlite3
+import sys
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+root_dir = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root_dir / 'tool'))
+
+import contract_sqlite_descender as desc
+
+
+def _make_dataset(path: Path) -> None:
+    table = pa.table({
+        'block_number': [1, 2, 3],
+        'address': ['0x1', '0x2', '0x3'],
+        'bytecode': ['aa', 'bb', 'cc'],
+    })
+    pq.write_table(table, path)
+
+
+def test_update_contract_db_reverse_basic(tmp_path):
+    data = tmp_path / 'data.parquet'
+    _make_dataset(data)
+    db = tmp_path / 'out.db'
+    desc.update_contract_db_reverse(str(db), size_limit_mb=1, parquet_path=str(data), page_rows=2)
+    conn = sqlite3.connect(db)
+    rows = [r[0] for r in conn.execute('SELECT block_number FROM contracts ORDER BY block_number DESC')]
+    meta = {k: v for k, v in conn.execute('SELECT key, value FROM meta')}
+    conn.close()
+    assert rows == [3, 2, 1]
+    assert meta['lowest_block'] == '0'
+
+
+def test_cli_gui_invoked(tmp_path, monkeypatch):
+    data = tmp_path / 'data.parquet'
+    _make_dataset(data)
+    db = tmp_path / 'out.db'
+
+    called = {}
+
+    def dummy_run(*args, **kwargs):
+        called['run'] = args
+
+    class DummyGUI:
+        def __init__(self, *args, **kwargs):
+            called['gui_init'] = args
+        def run(self):
+            called['gui_run'] = True
+
+    monkeypatch.setattr(desc, 'run', dummy_run)
+    monkeypatch.setattr(desc, 'SimpleGUI', DummyGUI)
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['contract_sqlite_descender.py', '--db', str(db), '--size-limit', '1', '--gui'],
+    )
+    desc.main()
+    assert called['gui_run']
+    assert called['run'][0] == desc.DEFAULT_PARQUET_DATASET
+    assert called['run'][4] == desc.DEFAULT_PAGE_ROWS
+

--- a/tool/contract_sqlite_descender.py
+++ b/tool/contract_sqlite_descender.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import time
+import threading
+from typing import Optional
+
+from contract_sqlite_loader import (
+    DEFAULT_PARQUET_DATASET,
+    _init_db,
+    _load_meta,
+    _save_meta,
+    _latest_block,
+)
+from data_getters import DataGetterAWSParquet
+
+DEFAULT_PAGE_ROWS = 2000
+
+
+def update_contract_db_reverse(
+    db_path: str,
+    *,
+    size_limit_mb: float,
+    parquet_path: str = DEFAULT_PARQUET_DATASET,
+    page_rows: int = DEFAULT_PAGE_ROWS,
+) -> None:
+    """Fill *db_path* with contract data starting from the newest block.
+
+    Contracts are fetched from *parquet_path* working backwards until the
+    database reaches ``size_limit_mb`` megabytes or block 0 is reached.
+    """
+    limit_bytes = int(size_limit_mb * 1024 * 1024)
+    getter = DataGetterAWSParquet(parquet_path, page_rows=page_rows)
+    conn = sqlite3.connect(db_path)
+    try:
+        _init_db(conn, limit_bytes)
+        meta = _load_meta(conn)
+        current = int(meta.get("lowest_block", _latest_block(parquet_path)))
+        highest = meta.get("highest_block")
+        if highest is None:
+            meta["highest_block"] = str(current)
+        while current >= 0 and os.path.getsize(db_path) < limit_bytes:
+            start = max(current - page_rows + 1, 0)
+            for page in getter.fetch_chunk(start, current):
+                for row in page:
+                    conn.execute(
+                        "INSERT OR IGNORE INTO contracts(address, bytecode, block_number) VALUES(?, ?, ?)",
+                        (row["Address"], row["ByteCode"], row["BlockNumber"]),
+                    )
+                conn.commit()
+            current = start - 1
+            meta["lowest_block"] = str(current + 1)
+            _save_meta(conn, meta)
+            if os.path.getsize(db_path) >= limit_bytes:
+                break
+    finally:
+        conn.close()
+
+
+def run(
+    parquet_path: str,
+    db_path: str,
+    size_limit_mb: float,
+    interval: float = 5.0,
+    page_rows: int = DEFAULT_PAGE_ROWS,
+) -> None:
+    """Continuously update ``db_path`` until the size limit is reached."""
+    while (
+        not os.path.exists(db_path)
+        or os.path.getsize(db_path) < size_limit_mb * 1024 * 1024
+    ):
+        update_contract_db_reverse(
+            db_path,
+            size_limit_mb=size_limit_mb,
+            parquet_path=parquet_path,
+            page_rows=page_rows,
+        )
+        if os.path.getsize(db_path) >= size_limit_mb * 1024 * 1024:
+            break
+        time.sleep(interval)
+
+
+class SimpleGUI:
+    """Very small curses UI showing the current lowest block."""
+
+    def __init__(self, parquet_path: str, db_path: str, size_limit_mb: float, interval: float = 5.0) -> None:
+        self.parquet_path = parquet_path
+        self.db_path = db_path
+        self.size_limit_mb = size_limit_mb
+        self.interval = interval
+
+    def _get_lowest(self) -> Optional[int]:
+        if not os.path.exists(self.db_path):
+            return None
+        conn = sqlite3.connect(self.db_path)
+        try:
+            _init_db(conn, int(self.size_limit_mb * 1024 * 1024))
+            meta = _load_meta(conn)
+            val = meta.get("lowest_block")
+            return int(val) if val is not None else None
+        finally:
+            conn.close()
+
+    def _loop(self, stdscr: "curses._CursesWindow") -> None:
+        import curses
+
+        stdscr.nodelay(True)
+        while True:
+            lowest = self._get_lowest()
+            stdscr.clear()
+            stdscr.addstr(0, 0, "Simple SQL Loader (q to quit)")
+            if lowest is not None:
+                stdscr.addstr(2, 0, f"Lowest block: {lowest}")
+            else:
+                stdscr.addstr(2, 0, "No data yet")
+            stdscr.refresh()
+            ch = stdscr.getch()
+            if ch == ord("q"):
+                break
+            time.sleep(0.5)
+
+    def run(self) -> None:
+        import curses
+
+        curses.wrapper(self._loop)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download contracts into SQLite descending")
+    parser.add_argument("--db", required=True, help="output SQLite database")
+    parser.add_argument("--size-limit", type=float, required=True, help="database size limit in MB")
+    parser.add_argument("--interval", type=float, default=5.0, help="update interval")
+    parser.add_argument("--page-rows", type=int, default=DEFAULT_PAGE_ROWS, help="rows per fetch chunk")
+    parser.add_argument("--gui", action="store_true", help="run with simple GUI")
+    args = parser.parse_args()
+
+    if args.gui:
+        gui = SimpleGUI(
+            DEFAULT_PARQUET_DATASET,
+            args.db,
+            args.size_limit,
+            interval=args.interval,
+        )
+        run_thread = threading.Thread(
+            target=run,
+            args=(
+                DEFAULT_PARQUET_DATASET,
+                args.db,
+                args.size_limit,
+                args.interval,
+                args.page_rows,
+            ),
+        )
+        run_thread.daemon = True
+        run_thread.start()
+        gui.run()
+    else:
+        run(
+            DEFAULT_PARQUET_DATASET,
+            args.db,
+            args.size_limit,
+            args.interval,
+            args.page_rows,
+        )
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add `contract_sqlite_descender.py` which downloads contract data from the AWS parquet dataset starting at the latest block and moving backwards
- include a minimal curses GUI displaying the lowest block processed
- add flags for database path, size limit and rows per page
- document usage in the README
- create `descender_report.md` summarizing the tool
- add tests covering new CLI behaviour

## Testing
- `pip install web3 z3-solver`
- `pip install pyarrow`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686488855d7c832d90747768397fd245