### PR TITLE
Add SQLite DB scan tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,8 @@ Additional tools:
   contracts in `contracts/contracts.jsonl` together with a metadata file.
   When no metadata exists and no block range is provided, the downloader uses
   the current `eth_blockNumber` as both start and end block.
+- `db_checker.py` scans contracts stored in a SQLite database and writes a JSON
+  report to `reports/db_scan_report.json` while showing live progress.
 
 - A `Dockerfile` in the repository root can build a container with all
   dependencies installed. Build it using `docker build -t maian .`.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,18 @@ The `db_head.py` helper prints the first few rows stored in the SQLite database.
 python tool/db_head.py contracts.db --count 3
 ```
 
+### Database Checker
+
+Contracts stored in a SQLite database can be scanned offline with
+`db_checker.py`. Provide the database path via `--db` and an optional
+`--limit` to restrict how many entries are processed. A JSON report is written
+to `reports/db_scan_report.json` by default and progress is printed after each
+contract.
+
+```
+python tool/db_checker.py --db contracts.db --limit 10
+```
+
 
 ### Using AWS Open Data
 

--- a/reports/db_checker_report.md
+++ b/reports/db_checker_report.md
@@ -1,0 +1,23 @@
+# Database Checker Report
+
+The new `db_checker.py` script scans contracts stored in a SQLite database using the
+existing Maian checks. A small test database containing two dummy contracts was
+created and scanned. No vulnerabilities were found.
+
+```
+$ python tool/db_checker.py --db sample.db --limit 2
+```
+
+Progress output during the run showed the number of contracts processed and the
+current vulnerability counts. The resulting summary was saved to
+`reports/db_scan_report.json`:
+
+```json
+{
+  "total": 2,
+  "scanned": 2,
+  "suicidal": 0,
+  "prodigal": 0,
+  "greedy": 0
+}
+```

--- a/reports/db_scan_report.json
+++ b/reports/db_scan_report.json
@@ -1,0 +1,7 @@
+{
+  "total": 2,
+  "scanned": 2,
+  "suicidal": 0,
+  "prodigal": 0,
+  "greedy": 0
+}

--- a/tests/test_db_checker.py
+++ b/tests/test_db_checker.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+import json
+import sqlite3
+import sys
+
+root_dir = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root_dir / 'tool'))
+
+import db_checker
+
+
+def _make_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE contracts (
+            address TEXT PRIMARY KEY,
+            bytecode TEXT NOT NULL,
+            block_number INTEGER NOT NULL
+        )
+        """
+    )
+    rows = [
+        ('0x1', 'aa', 1),
+        ('0x2', 'bb', 2),
+    ]
+    conn.executemany(
+        'INSERT INTO contracts(address, bytecode, block_number) VALUES(?, ?, ?)',
+        rows,
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_scan_database(monkeypatch, tmp_path):
+    db = tmp_path / 'c.db'
+    _make_db(db)
+
+    results = [
+        {'suicidal': True, 'prodigal': False, 'greedy': False},
+        {'suicidal': False, 'prodigal': True, 'greedy': True},
+    ]
+
+    def fake_run(bytecode: str, address: str):
+        return results.pop(0)
+
+    monkeypatch.setattr(db_checker, 'run_checks', fake_run)
+
+    msgs: list[str] = []
+    summary = db_checker.scan_database(str(db), progress_cb=msgs.append)
+    assert summary == {
+        'total': 2,
+        'scanned': 2,
+        'suicidal': 1,
+        'prodigal': 1,
+        'greedy': 1,
+    }
+    assert msgs
+
+
+def test_cli_writes_report(monkeypatch, tmp_path):
+    db = tmp_path / 'c.db'
+    report = tmp_path / 'out.json'
+    _make_db(db)
+
+    monkeypatch.setattr(
+        db_checker,
+        'run_checks',
+        lambda b, a: {'suicidal': False, 'prodigal': False, 'greedy': False},
+    )
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['db_checker.py', '--db', str(db), '--report', str(report)]
+    )
+    db_checker.main()
+    data = json.loads(report.read_text())
+    assert data['scanned'] == 2
+

--- a/tool/db_checker.py
+++ b/tool/db_checker.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from typing import Callable, Dict, Optional
+
+from fetch_and_check import run_checks
+
+
+ProgressCB = Optional[Callable[[str], None]]
+
+
+def scan_database(
+    db_path: str,
+    *,
+    limit: int | None = None,
+    progress_cb: ProgressCB = None,
+) -> Dict[str, int]:
+    """Run Maian checks on contracts stored in ``db_path``.
+
+    Parameters
+    ----------
+    db_path:
+        SQLite database containing a ``contracts`` table with ``address`` and
+        ``bytecode`` columns.
+    limit:
+        Optional maximum number of contracts to scan.
+    progress_cb:
+        Optional callback invoked after each contract is processed. Receives a
+        human readable progress string.
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        total = conn.execute("SELECT COUNT(*) FROM contracts").fetchone()[0]
+        cur = conn.execute("SELECT address, bytecode FROM contracts")
+        scanned = 0
+        flagged = {"suicidal": 0, "prodigal": 0, "greedy": 0}
+        for address, bytecode in cur:
+            res = run_checks(bytecode, address)
+            scanned += 1
+            for key in flagged:
+                if res.get(key):
+                    flagged[key] += 1
+            if progress_cb:
+                remaining = max(total - scanned, 0)
+                progress_cb(
+                    f"{scanned}/{total} scanned - "
+                    f"S:{flagged['suicidal']} P:{flagged['prodigal']} "
+                    f"G:{flagged['greedy']} left:{remaining}"
+                )
+            if limit is not None and scanned >= limit:
+                break
+    finally:
+        conn.close()
+    result = {"total": total, "scanned": scanned}
+    result.update(flagged)
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run Maian checks on a contract database")
+    parser.add_argument("--db", required=True, help="SQLite database with contracts")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        help="optional limit on number of contracts to scan",
+    )
+    parser.add_argument(
+        "--report",
+        default="reports/db_scan_report.json",
+        help="output file for the JSON report",
+    )
+    args = parser.parse_args()
+    summary = scan_database(args.db, limit=args.limit, progress_cb=print)
+    with open(args.report, "w", encoding="utf-8") as fh:
+        json.dump(summary, fh, indent=2)
+    print(f"Report written to {args.report}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `db_checker.py` for scanning contracts stored in SQLite
- document usage of the new tool in README
- log the tool in `AGENTS.md`
- provide a short sample run report
- add unit tests for the checker

## Testing
- `pip install web3 z3-solver`
- `pip install pyarrow`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68649bacf4c4832da60c6c006038629a