### PR TITLE
Improve AWS scanner progress output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,13 @@ Additional tools:
   the current `eth_blockNumber` as both start and end block.
 - `db_checker.py` scans contracts stored in a SQLite database and writes a JSON
   report to `reports/db_scan_report.json` while showing live progress.
+- `aws_scanner.py` reads contracts from the AWS Open-Data Parquet dump. It
+  processes the newest 1000 blocks by default and prints live progress. Pass
+  `--continuous` to keep scanning in a loop. Results are appended to
+  `reports/aws_scan_results.jsonl` and progress is shown on one line. Adjust the
+  block range with `--batch-blocks`. The scanner defaults to
+  `s3://aws-public-blockchain/v1.0/eth/contracts/` when no dataset path is
+  supplied.
 
 - A `Dockerfile` in the repository root can build a container with all
   dependencies installed. Build it using `docker build -t maian .`.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,26 @@ for page in getter.fetch_chunk(100000, 100100):
         print(row["Address"], row["BlockNumber"])
 ```
 
+### AWS Scanner
+
+`aws_scanner.py` inspects contracts from the AWS dataset. By default it
+processes the newest 1000 blocks and exits. Progress updates showing the current
+block and number of checked contracts are printed live to the terminal. The
+script stores its state in `reports/aws_scanner_state.json` and appends scan
+results to `reports/aws_scan_results.jsonl`. When no dataset path is provided,
+the tool uses the AWS Open-Data bucket
+`s3://aws-public-blockchain/v1.0/eth/contracts/`.
+
+```bash
+python tool/aws_scanner.py             # use default dataset
+python tool/aws_scanner.py s3://bucket/path  # custom path
+```
+
+Add `--continuous` to keep scanning in a loop. By default the tool inspects
+1000 blocks per iteration, starting from the latest block on the first run and
+moving backwards. Use `--batch-blocks` to change the range, `--interval` to
+adjust the pause between runs and `--max-rounds` to limit the number of loops.
+
 ## Installation
 
 Maian requires Python 3.8 or newer. Install the Python dependencies using:

--- a/reports/aws_scanner_report.md
+++ b/reports/aws_scanner_report.md
@@ -1,0 +1,29 @@
+# AWS Scanner Report
+
+The `aws_scanner.py` utility scans smart contract bytecode from the AWS
+Open-Data Parquet dump. It keeps a small JSON state to resume from the
+latest processed block and appends results as JSON lines. Each iteration
+inspects a range of blocks (1000 by default) starting from the highest block
+number and moving backwards.
+
+## Design
+- Uses `DataGetterAWSParquet` to read contracts from Parquet files.
+- Calls `run_checks` on each contract and records the vulnerability flags.
+- State is stored in `reports/aws_scanner_state.json` with the next block to
+  inspect and the last known highest block number.
+- Progress output is printed on a single line using a callback returned by
+  `make_live_progress`.
+
+## Usage
+Run a single scan of the newest 1000 blocks:
+
+```bash
+python tool/aws_scanner.py                 # uses default dataset
+python tool/aws_scanner.py s3://bucket/path  # custom path
+```
+The default dataset path is
+`s3://aws-public-blockchain/v1.0/eth/contracts/`.
+
+Add `--continuous` to keep scanning in a loop. Each pass handles 1000 blocks by
+default. Change this with `--batch-blocks`, use `--interval` to adjust the pause
+between iterations and `--max-rounds` to limit the number of loops.

--- a/tests/test_aws_scanner.py
+++ b/tests/test_aws_scanner.py
@@ -70,3 +70,103 @@ def test_scan_once_resumes_and_handles_new_blocks(tmp_path, monkeypatch):
     lines = report.read_text().splitlines()
     assert len(lines) == 2
 
+
+def test_scan_once_multiple_blocks(tmp_path, monkeypatch):
+    data = tmp_path / 'data.parquet'
+    _make_dataset(data, [1, 2, 3, 4])
+    state = tmp_path / 'state.json'
+    report = tmp_path / 'report.jsonl'
+    monkeypatch.setattr(aws_scanner, 'run_checks', lambda b, a: {})
+    aws_scanner.scan_once(
+        str(data),
+        state_file=str(state),
+        report_file=str(report),
+        batch_blocks=2,
+        page_rows=2,
+    )
+    st = json.loads(state.read_text())
+    # next_block should move back by 2 blocks
+    assert st['next_block'] == 2
+    lines = report.read_text().splitlines()
+    assert len(lines) == 2
+
+
+def test_make_live_progress_writes(capsys):
+    cb = aws_scanner.make_live_progress()
+    cb("hello")
+    out = capsys.readouterr().out
+    assert "hello" in out
+
+
+def test_main_runs_once_by_default(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_scan_once(*args, **kwargs):
+        called.update(kwargs)
+
+    def fake_run_continuous(*args, **kwargs):
+        called["cont"] = True
+
+    monkeypatch.setattr(aws_scanner, "scan_once", fake_scan_once)
+    monkeypatch.setattr(aws_scanner, "run_continuous", fake_run_continuous)
+    state = tmp_path / "state.json"
+    report = tmp_path / "report.jsonl"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "aws_scanner.py",
+            str(tmp_path / "data.parquet"),
+            "--state-file",
+            str(state),
+            "--report-file",
+            str(report),
+        ],
+    )
+    aws_scanner.main()
+    assert called.get("batch_blocks") == 1000
+    assert "cont" not in called
+
+
+def test_main_continuous_flag(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_run_continuous(*args, **kwargs):
+        called.update(kwargs)
+
+    monkeypatch.setattr(aws_scanner, "run_continuous", fake_run_continuous)
+    monkeypatch.setattr(aws_scanner, "scan_once", lambda *a, **k: None)
+    state = tmp_path / "state.json"
+    report = tmp_path / "report.jsonl"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "aws_scanner.py",
+            str(tmp_path / "data.parquet"),
+            "--continuous",
+            "--max-rounds",
+            "2",
+            "--state-file",
+            str(state),
+            "--report-file",
+            str(report),
+        ],
+    )
+    aws_scanner.main()
+    assert called.get("max_rounds") == 2
+    assert called.get("batch_blocks") == 1000
+
+
+def test_main_uses_default_dataset(monkeypatch):
+    captured = {}
+
+    def fake_scan_once(path, **kwargs):
+        captured["path"] = path
+
+    monkeypatch.setattr(aws_scanner, "scan_once", fake_scan_once)
+    monkeypatch.setattr(aws_scanner, "run_continuous", lambda *a, **k: None)
+    monkeypatch.setattr(sys, "argv", ["aws_scanner.py"])  # no dataset arg
+    aws_scanner.main()
+    assert captured["path"] == aws_scanner.DEFAULT_PARQUET_DATASET
+


### PR DESCRIPTION
## Summary
- show live progress on one line in `aws_scanner.py`
- document the new AWS scanner behaviour in README
- describe the new tool in AGENTS.md
- test the progress callback
- allow single-run or continuous operation via CLI flag
- add report describing AWS scanner design and usage
- handle variable block batches when scanning continuous AWS dumps
- clarify default dataset path in docs and tests

## Testing
- `pip install web3 z3-solver pyarrow`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864b2dac11c832da24e8aa6845a1d1e