### PR TITLE
Update aws scanner results filtering

### DIFF
--- a/tests/test_aws_scanner.py
+++ b/tests/test_aws_scanner.py
@@ -68,7 +68,7 @@ def test_scan_once_resumes_and_handles_new_blocks(tmp_path, monkeypatch):
     st = json.loads(state.read_text())
     assert st['next_block'] == 3
     lines = report.read_text().splitlines()
-    assert len(lines) == 2
+    assert len(lines) == 0
 
 
 def test_scan_once_multiple_blocks(tmp_path, monkeypatch):
@@ -88,7 +88,7 @@ def test_scan_once_multiple_blocks(tmp_path, monkeypatch):
     # next_block should move back by 2 blocks
     assert st['next_block'] == 2
     lines = report.read_text().splitlines()
-    assert len(lines) == 2
+    assert len(lines) == 0
 
 
 def test_make_live_progress_writes(capsys):

--- a/tool/aws_scanner.py
+++ b/tool/aws_scanner.py
@@ -93,7 +93,13 @@ def scan_once(
                     "prodigal": bool(res.get("prodigal")),
                     "greedy": bool(res.get("greedy")),
                 }
-                out.write(json.dumps(entry) + "\n")
+                if entry["suicidal"] or entry["prodigal"] or entry["greedy"]:
+                    out.write(json.dumps(entry) + "\n")
+                    logger.info(
+                        "vulnerable address %s at block %d",
+                        entry["address"],
+                        entry["block"],
+                    )
                 processed += 1
                 if progress_cb:
                     progress_cb(
@@ -110,7 +116,7 @@ def scan_once(
 def run_continuous(
     parquet_path: str,
     *,
-    interval: float = 5.0,
+    interval: float = 0.0,
     batch_blocks: int = 1000,
     state_file: str = DEFAULT_STATE_FILE,
     report_file: str = DEFAULT_REPORT_FILE,
@@ -131,7 +137,8 @@ def run_continuous(
             progress_cb=make_live_progress(),
         )
         rounds += 1
-        time.sleep(interval)
+        if interval > 0:
+            time.sleep(interval)
 
 
 def main() -> None:
@@ -144,7 +151,7 @@ def main() -> None:
     )
     parser.add_argument("--state-file", default=DEFAULT_STATE_FILE)
     parser.add_argument("--report-file", default=DEFAULT_REPORT_FILE)
-    parser.add_argument("--interval", type=float, default=5.0)
+    parser.add_argument("--interval", type=float, default=0.0)
     parser.add_argument(
         "--batch-blocks", type=int, default=1000,
         help="number of blocks to scan per iteration"


### PR DESCRIPTION
## Summary
- only write AWS results when a contract triggers a check
- log discovered vulnerable addresses
- remove the default pause between continuous scans
- adapt AWS scanner tests for filtered results

## Testing
- `pip install web3 z3-solver`
- `pip install pyarrow`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864bede4460832da402039eb2010d8a