### PR TITLE
Add AWS Parquet speed measurement utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,17 @@ Add `--continuous` to keep scanning in a loop. By default the tool inspects
 moving backwards. Use `--batch-blocks` to change the range, `--interval` to
 adjust the pause between runs and `--max-rounds` to limit the number of loops.
 
+### AWS Speed Test
+
+`aws_speed.py` measures the throughput of `DataGetterAWSParquet`. It reads a
+range of blocks and reports how many contracts and bytes were downloaded along
+with the elapsed time and average MB/s.
+
+```bash
+python tool/aws_speed.py              # use default dataset
+python tool/aws_speed.py s3://bucket/path --blocks 5000
+```
+
 ## Installation
 
 Maian requires Python 3.8 or newer. Install the Python dependencies using:

--- a/tests/test_aws_speed.py
+++ b/tests/test_aws_speed.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+import sys
+root_dir = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root_dir / 'tool'))
+
+import aws_speed
+
+
+def _make_dataset(path: Path) -> None:
+    table = pa.table({
+        'block_number': [1, 2, 3],
+        'address': ['0x1', '0x2', '0x3'],
+        'bytecode': ['aa', 'bb', 'cc'],
+    })
+    pq.write_table(table, path)
+
+
+def test_measure_speed_basic(tmp_path, monkeypatch):
+    data = tmp_path / 'data.parquet'
+    _make_dataset(data)
+    times = iter([0.0, 2.0])
+    monkeypatch.setattr(aws_speed.time, 'time', lambda: next(times))
+    stats = aws_speed.measure_speed(str(data), 1, 3, page_rows=2)
+    assert stats['contracts'] == 3
+    assert stats['bytes'] == 3
+    assert stats['seconds'] == 2.0
+    assert stats['mb_per_second'] > 0
+
+
+def test_main_prints_stats(tmp_path, monkeypatch, capsys):
+    data = tmp_path / 'data.parquet'
+    _make_dataset(data)
+    monkeypatch.setattr(aws_speed, '_latest_block', lambda p: 3)
+    times = iter([0.0, 1.0])
+    monkeypatch.setattr(aws_speed.time, 'time', lambda: next(times))
+    monkeypatch.setattr(sys, 'argv', ['aws_speed.py', str(data), '--blocks', '3'])
+    aws_speed.main()
+    out = capsys.readouterr().out
+    assert 'MB/s' in out
+

--- a/tool/aws_speed.py
+++ b/tool/aws_speed.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import argparse
+import time
+from typing import Dict
+
+from contract_sqlite_loader import DEFAULT_PARQUET_DATASET
+from aws_scanner import _latest_block
+from data_getters import DataGetterAWSParquet
+
+
+def measure_speed(
+    dataset: str,
+    start_block: int,
+    end_block: int,
+    *,
+    page_rows: int = 2000,
+) -> Dict[str, float]:
+    """Return download statistics for the given block range.
+
+    The function measures how many contracts and raw bytes are
+    retrieved from ``dataset`` between ``start_block`` and ``end_block``.
+    ``page_rows`` controls the page size for :class:`DataGetterAWSParquet`.
+    """
+    getter = DataGetterAWSParquet(dataset, page_rows=page_rows)
+    total_bytes = 0
+    total_contracts = 0
+    t_start = time.time()
+    for page in getter.fetch_chunk(start_block, end_block):
+        for row in page:
+            total_bytes += len(bytes.fromhex(row["ByteCode"]))
+            total_contracts += 1
+    elapsed = time.time() - t_start
+    mb_per_s = (total_bytes / 1_000_000) / elapsed if elapsed else 0.0
+    return {
+        "contracts": total_contracts,
+        "bytes": total_bytes,
+        "seconds": elapsed,
+        "mb_per_second": mb_per_s,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Measure download speed for the AWS Parquet dataset"
+    )
+    parser.add_argument(
+        "dataset",
+        nargs="?",
+        default=DEFAULT_PARQUET_DATASET,
+        help="Parquet dataset path",
+    )
+    parser.add_argument(
+        "--blocks",
+        type=int,
+        default=1000,
+        help="number of newest blocks to fetch",
+    )
+    parser.add_argument("--page-rows", type=int, default=2000)
+    args = parser.parse_args()
+
+    end_block = _latest_block(args.dataset)
+    start_block = max(end_block - args.blocks + 1, 0)
+    stats = measure_speed(
+        args.dataset,
+        start_block,
+        end_block,
+        page_rows=args.page_rows,
+    )
+    print(
+        f"Fetched {stats['contracts']} contracts "
+        f"({stats['bytes']} bytes) in {stats['seconds']:.2f}s -> "
+        f"{stats['mb_per_second']:.2f} MB/s"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `aws_speed.py` to measure AWS Parquet download speed
- include tests for the new module
- document `aws_speed.py` usage in README

## Testing
- `pip install web3 z3-solver`
- `pip install pyarrow`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686584aae9e8832d8952a1dcebc06ef4