### PR TITLE
Add Java-based BigQuery scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,21 @@ custom table name via `--dataset`.
 python tool/bigquery_contracts.py --start-block 1000000 --end-block 1000100
 ```
 
+### Java BigQuery Scanner
+
+`java_bigquery_scanner.py` uses a small Java helper to query the same dataset
+and immediately run Maian's checks on the downloaded contracts. Compile the
+helper and run the scanner like so:
+
+```bash
+javac tool/java/BigQueryFetcher.java
+python tool/java_bigquery_scanner.py --start-block 1000000 --end-block 1000100 --jar-path tool/java
+```
+
+The script stores the fetched contracts in
+`contracts/java_bigquery_contracts.jsonl` and prints a JSON report for each
+entry.
+
 ## Installation
 
 Maian requires Python 3.8 or newer. Install the Python dependencies using:

--- a/tests/test_java_bigquery_scanner.py
+++ b/tests/test_java_bigquery_scanner.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+import sys
+import json
+
+root_dir = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root_dir / 'tool'))
+
+import java_bigquery_scanner
+
+
+def test_scan_bigquery_with_java(monkeypatch, tmp_path):
+    out_file = tmp_path / 'contracts.jsonl'
+
+    def fake_fetcher(jar, dataset, start, end, output):
+        data = [
+            {"Address": "0x1", "ByteCode": "aa", "BlockNumber": 1},
+            {"Address": "0x2", "ByteCode": "bb", "BlockNumber": 2},
+        ]
+        with open(output, 'w', encoding='utf-8') as fh:
+            for row in data:
+                fh.write(json.dumps(row) + '\n')
+
+    monkeypatch.setattr(java_bigquery_scanner, 'run_java_fetcher', fake_fetcher)
+
+    results = iter([
+        {"suicidal": False, "prodigal": False, "greedy": False},
+        {"suicidal": True, "prodigal": False, "greedy": True},
+    ])
+    monkeypatch.setattr(java_bigquery_scanner, 'run_checks', lambda b, a: next(results))
+
+    reports = java_bigquery_scanner.scan_bigquery_with_java(
+        'dataset.table',
+        1,
+        2,
+        jar_path='dummy',
+        output_file=str(out_file),
+    )
+    assert len(reports) == 2
+    assert reports[1]['suicidal']

--- a/tool/java/BigQueryFetcher.java
+++ b/tool/java/BigQueryFetcher.java
@@ -1,0 +1,62 @@
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.TableResult;
+import com.google.cloud.bigquery.FieldValueList;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+/**
+ * Fetch contract data from Google BigQuery and write JSON lines.
+ *
+ * Usage:
+ *  java -cp <classpath> BigQueryFetcher --dataset <table> --start-block <start> --end-block <end> --output <file>
+ */
+public class BigQueryFetcher {
+    public static void main(String[] args) throws Exception {
+        String dataset = "bigquery-public-data.crypto_ethereum.contracts";
+        long startBlock = 0;
+        long endBlock = 0;
+        String output = "contracts.jsonl";
+
+        for (int i = 0; i < args.length; i++) {
+            switch (args[i]) {
+                case "--dataset":
+                    dataset = args[++i];
+                    break;
+                case "--start-block":
+                    startBlock = Long.parseLong(args[++i]);
+                    break;
+                case "--end-block":
+                    endBlock = Long.parseLong(args[++i]);
+                    break;
+                case "--output":
+                    output = args[++i];
+                    break;
+                default:
+                    System.err.println("Unknown arg: " + args[i]);
+            }
+        }
+
+        BigQuery bigquery = BigQueryOptions.getDefaultInstance().getService();
+        String query = String.format(
+            "SELECT address, bytecode, block_number FROM `%s` " +
+            "WHERE block_number >= %d AND block_number <= %d ORDER BY block_number",
+            dataset, startBlock, endBlock);
+        QueryJobConfiguration config = QueryJobConfiguration.newBuilder(query).build();
+        TableResult result = bigquery.query(config);
+        try (PrintWriter out = new PrintWriter(new FileWriter(output))) {
+            for (FieldValueList row : result.iterateAll()) {
+                String address = row.get("address").getStringValue();
+                String bytecode = row.get("bytecode").getStringValue();
+                long blockNumber = row.get("block_number").getLongValue();
+                String line = String.format(
+                    "{\"Address\":\"%s\",\"ByteCode\":\"%s\",\"BlockNumber\":%d}",
+                    address, bytecode, blockNumber);
+                out.println(line);
+            }
+        }
+    }
+}

--- a/tool/java_bigquery_scanner.py
+++ b/tool/java_bigquery_scanner.py
@@ -1,0 +1,92 @@
+"""Run Maian checks on contracts fetched via a Java BigQuery client."""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from typing import Dict, List
+
+from fetch_and_check import run_checks
+
+
+def run_java_fetcher(
+    jar_path: str,
+    dataset: str,
+    start_block: int,
+    end_block: int,
+    output_file: str,
+) -> None:
+    """Execute the Java fetcher to retrieve contract data."""
+    cmd = [
+        "java",
+        "-cp",
+        jar_path,
+        "BigQueryFetcher",
+        "--dataset",
+        dataset,
+        "--start-block",
+        str(start_block),
+        "--end-block",
+        str(end_block),
+        "--output",
+        output_file,
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def scan_bigquery_with_java(
+    dataset: str,
+    start_block: int,
+    end_block: int,
+    *,
+    jar_path: str = "tool/java",
+    output_file: str = "contracts/java_bigquery_contracts.jsonl",
+) -> List[Dict[str, object]]:
+    """Fetch contracts with the Java tool and run Maian checks."""
+    run_java_fetcher(jar_path, dataset, start_block, end_block, output_file)
+    reports: List[Dict[str, object]] = []
+    with open(output_file, "r", encoding="utf-8") as fh:
+        for line in fh:
+            row = json.loads(line)
+            res = run_checks(row["ByteCode"], row["Address"])
+            res["address"] = row["Address"]
+            res["block_number"] = row["BlockNumber"]
+            reports.append(res)
+    return reports
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fetch contracts from BigQuery using a Java helper and run Maian checks"
+    )
+    parser.add_argument(
+        "--dataset",
+        default="bigquery-public-data.crypto_ethereum.contracts",
+        help="BigQuery table with contract data",
+    )
+    parser.add_argument("--start-block", type=int, required=True)
+    parser.add_argument("--end-block", type=int, required=True)
+    parser.add_argument(
+        "--jar-path",
+        default="tool/java",
+        help="path to compiled BigQueryFetcher class or jar",
+    )
+    parser.add_argument(
+        "--output-file",
+        default="contracts/java_bigquery_contracts.jsonl",
+        help="destination JSONL file",
+    )
+    args = parser.parse_args()
+    reports = scan_bigquery_with_java(
+        args.dataset,
+        args.start_block,
+        args.end_block,
+        jar_path=args.jar_path,
+        output_file=args.output_file,
+    )
+    for rep in reports:
+        print(json.dumps(rep))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `BigQueryFetcher.java` for querying BigQuery from Java
- add `java_bigquery_scanner.py` to run Maian checks on fetched contracts
- document the Java scanner in the README
- test scanning with a mocked Java fetcher

## Testing
- `pip install web3 z3-solver`
- `pip install pyarrow`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865c683efc0832dba57fb725465fb56