### PR TITLE
Add SQLite leak scanner tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ contract.
 python tool/db_checker.py --db contracts.db --limit 10
 ```
 
+### Database Leak Scanner
+
+Unchecked contracts can be tested for prodigal leaks with
+`db_leak_scanner.py`. Provide the source database via `--src-db` and a
+destination database for vulnerable contracts with `--dst-db`. Each processed
+row is marked as checked.
+
+```bash
+python tool/db_leak_scanner.py --src-db contracts.db --dst-db leaks.db
+```
+
 
 ### Using AWS Open Data
 

--- a/tests/test_db_leak_scanner.py
+++ b/tests/test_db_leak_scanner.py
@@ -1,0 +1,78 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+root_dir = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root_dir / 'tool'))
+
+import db_leak_scanner
+
+
+def _make_src_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE contracts (
+            address TEXT PRIMARY KEY,
+            bytecode TEXT NOT NULL,
+            block_number INTEGER NOT NULL,
+            checked INTEGER
+        )
+        """
+    )
+    rows = [
+        ('0x1', 'aa', 1, 0),
+        ('0x2', 'bb', 2, 1),  # already checked
+        ('0x3', 'cc', 3, 0),
+    ]
+    conn.executemany(
+        'INSERT INTO contracts(address, bytecode, block_number, checked) VALUES(?, ?, ?, ?)',
+        rows,
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_scan_for_leaks(monkeypatch, tmp_path):
+    src = tmp_path / 'src.db'
+    dst = tmp_path / 'dst.db'
+    _make_src_db(src)
+
+    results = [
+        {'prodigal': True},
+        {'prodigal': False},
+    ]
+
+    def fake_run(bytecode: str, address: str):
+        return results.pop(0)
+
+    monkeypatch.setattr(db_leak_scanner, 'run_checks', fake_run)
+
+    summary = db_leak_scanner.scan_for_leaks(str(src), str(dst), progress_cb=lambda _: None)
+    assert summary['scanned'] == 2
+    assert summary['vulnerable'] == 1
+
+    conn = sqlite3.connect(src)
+    checked = dict(conn.execute('SELECT address, checked FROM contracts'))
+    conn.close()
+    assert checked == {'0x1': 1, '0x2': 1, '0x3': 1}
+
+    conn = sqlite3.connect(dst)
+    rows = list(conn.execute('SELECT address, block_number FROM contracts'))
+    conn.close()
+    assert rows == [('0x1', 1)]
+
+
+def test_cli_runs(monkeypatch, tmp_path):
+    src = tmp_path / 'src.db'
+    dst = tmp_path / 'dst.db'
+    _make_src_db(src)
+
+    monkeypatch.setattr(db_leak_scanner, 'run_checks', lambda b, a: {'prodigal': False})
+    monkeypatch.setattr(sys, 'argv', ['db_leak_scanner.py', '--src-db', str(src), '--dst-db', str(dst)])
+    db_leak_scanner.main()
+
+    conn = sqlite3.connect(src)
+    checked = [r[0] for r in conn.execute('SELECT checked FROM contracts ORDER BY address')]
+    conn.close()
+    assert checked == [1, 1, 1]

--- a/tool/db_leak_scanner.py
+++ b/tool/db_leak_scanner.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from typing import Callable, Optional, Dict
+
+from fetch_and_check import run_checks
+
+ProgressCB = Optional[Callable[[str], None]]
+
+
+def scan_for_leaks(
+    src_db: str,
+    dst_db: str,
+    *,
+    limit: Optional[int] = None,
+    progress_cb: ProgressCB = None,
+) -> Dict[str, int]:
+    """Scan unchecked contracts in ``src_db`` for leak vulnerabilities.
+
+    Contracts marked as vulnerable are inserted into ``dst_db``.
+    Returns a summary with the number of scanned and vulnerable entries.
+    """
+    src_conn = sqlite3.connect(src_db)
+    dst_conn = sqlite3.connect(dst_db)
+    try:
+        dst_conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS contracts (
+                address TEXT PRIMARY KEY,
+                bytecode TEXT NOT NULL,
+                block_number INTEGER NOT NULL
+            )
+            """
+        )
+        dst_conn.commit()
+
+        total = src_conn.execute(
+            "SELECT COUNT(*) FROM contracts WHERE checked IS NULL OR checked=0"
+        ).fetchone()[0]
+        cur = src_conn.execute(
+            "SELECT address, block_number, bytecode FROM contracts "
+            "WHERE checked IS NULL OR checked=0"
+        )
+        scanned = 0
+        vulnerable = 0
+        for address, block, bytecode in cur:
+            res = run_checks(bytecode, address)
+            if res.get("prodigal"):
+                dst_conn.execute(
+                    "INSERT OR REPLACE INTO contracts(address, bytecode, block_number) "
+                    "VALUES(?, ?, ?)",
+                    (address, bytecode, block),
+                )
+                dst_conn.commit()
+                vulnerable += 1
+            src_conn.execute(
+                "UPDATE contracts SET checked=1 WHERE address=?",
+                (address,),
+            )
+            src_conn.commit()
+            scanned += 1
+            if progress_cb:
+                progress_cb(f"{scanned}/{total} scanned")
+            if limit is not None and scanned >= limit:
+                break
+    finally:
+        src_conn.close()
+        dst_conn.close()
+    return {"scanned": scanned, "vulnerable": vulnerable, "total": total}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Scan database for leak vulnerabilities")
+    parser.add_argument("--src-db", required=True, help="SQLite database with contracts")
+    parser.add_argument("--dst-db", required=True, help="SQLite database for vulnerable contracts")
+    parser.add_argument("--limit", type=int, help="optional limit on number of contracts to scan")
+    args = parser.parse_args()
+    summary = scan_for_leaks(args.src_db, args.dst_db, limit=args.limit, progress_cb=print)
+    print()
+    print(summary)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `db_leak_scanner.py` for scanning unchecked contracts for prodigal leaks
- add tests for the new leak scanner
- document leak scanner in README

## Testing
- `pip install web3 z3-solver pyarrow google-cloud-bigquery`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866fcda8a68832db802997088147047